### PR TITLE
Add MeTTaCodeRetrieval Module for Semantic and Metadata-Based Code Search

### DIFF
--- a/MeTTaCodeRetrieval/.gitignore
+++ b/MeTTaCodeRetrieval/.gitignore
@@ -1,0 +1,6 @@
+populate_mongo.py
+test_mongo.py
+test_qdrant.py
+test_embeddinggemma.py
+
+.env

--- a/MeTTaCodeRetrieval/README.md
+++ b/MeTTaCodeRetrieval/README.md
@@ -1,0 +1,45 @@
+# MeTTa Code Retrieval Module
+
+## Overview
+This module is a component of a larger project for managing and processing MeTTa code. It provides semantic and metadata-based retrieval of MeTTa code snippets stored in a MongoDB database (`chunkDB.chunks`). The module fetches unembedded chunks (`isEmbedded: False`), embeds them into 768-dimensional vectors, stores them in Qdrant, and updates `isEmbedded` to `True`. It supports hybrid searches combining semantic similarity (e.g., "recursive function") with metadata filters (e.g., `repo`, `source`, `isEmbedded`).
+
+### Functionality
+- Retrieves MeTTa code chunks from MongoDB (`chunkDB.chunks`) that have not been embedded (`isEmbedded: False`).
+- Embeds chunk content using `google/embeddinggemma-300m` into 768-dimensional vectors.
+- Stores embeddings in Qdrant’s `metta_codebase` collection with metadata (`chunkId`, `source`, `chunk`, `project`, `repo`, `section`, `file`, `version`, `isEmbedded`).
+- Updates `isEmbedded` to `True` in MongoDB after successful embedding to prevent re-embedding.
+- Enables semantic searches (e.g., "recursive function") and metadata-filtered searches (e.g., `repo="github.com/trueagi-io/hyperon-experimental"`, `source="code"`, `isEmbedded=True`).
+
+### Technologies Used
+- **MongoDB**: Stores MeTTa code chunks in the `chunkDB.chunks` collection (local for testing, MongoDB Atlas in production).
+- **Qdrant**: Manages vector storage and search in the `metta_codebase` collection.
+- **google/embeddinggemma-300m**: Generates 768-dimensional embeddings for MeTTa code.
+- **Python**: Implements the pipeline using libraries like `pymongo`, `qdrant-client`, `sentence-transformers`, and `python-dotenv`.
+- **Docker**: Runs Qdrant locally for development.
+
+### Integration
+- Uses the project’s `chunkDB.chunks` schema for metadata-based indexing.
+- Supports local MongoDB for development and testing, with production deployment using the project’s MongoDB Atlas cluster.
+- Integrates with the larger project’s data pipeline, potentially alongside FastAPI endpoints for search or ingestion.
+- Ensures efficient embedding by checking `isEmbedded` status.
+
+## Usage
+- **Run a Search**:
+  ```
+  python search_metta_code.py
+  ```
+  - Example queries:
+    - Semantic: `"recursive function"`.
+    - Filtered by repo: `"recursive function"` from `"github.com/trueagi-io/hyperon-experimental"`.
+    - Filtered by source: `"graph relation"` with `source="code"`.
+    - Filtered by embedding status: `"multivalued propagation"` with `is_embedded_filter=False`.
+
+- **Customize Searches**:
+  Modify `search_metta_code.py`:
+  ```python
+  search_metta_code(
+      query="multivalued propagation",
+      repo_filter="github.com/trueagi-io/hyperon-experimental",
+      source_filter="code"
+  )
+  ```

--- a/MeTTaCodeRetrieval/create_qdrant_collection.py
+++ b/MeTTaCodeRetrieval/create_qdrant_collection.py
@@ -1,0 +1,31 @@
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import Distance, VectorParams
+
+# Configuration
+QDRANT_URL = "http://localhost:6333"
+COLLECTION_NAME = "metta_codebase"
+EMBEDDING_DIM = 768  # Dimension for google/embeddinggemma-300m
+
+# Initialize client
+client = QdrantClient(url=QDRANT_URL, timeout=5)
+
+# Check and recreate collection if needed
+try:
+    collections = client.get_collections()
+    if COLLECTION_NAME in [col.name for col in collections.collections]:
+        # Delete existing collection to update vector size
+        client.delete_collection(collection_name=COLLECTION_NAME)
+        print(f"Deleted existing collection: {COLLECTION_NAME}")
+    
+    # Create collection with correct vector size
+    client.create_collection(
+        collection_name=COLLECTION_NAME,
+        vectors_config=VectorParams(size=EMBEDDING_DIM, distance=Distance.COSINE)
+    )
+    print(f"Created collection: {COLLECTION_NAME} with vector size {EMBEDDING_DIM}")
+    
+    # Verify
+    collections = client.get_collections()
+    print("Current collections:", [col.name for col in collections.collections])
+except Exception as e:
+    print("Failed to update collection:", str(e))

--- a/MeTTaCodeRetrieval/embed_metta_to_qdrant.py
+++ b/MeTTaCodeRetrieval/embed_metta_to_qdrant.py
@@ -1,0 +1,94 @@
+import os
+import asyncio
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import PointStruct
+from sentence_transformers import SentenceTransformer
+from pymongo import AsyncMongoClient
+import uuid
+from dotenv import load_dotenv
+
+# Load environment variables
+load_dotenv()
+MONGO_URI = os.getenv("MONGO_URI")
+if not MONGO_URI:
+    raise ValueError("MONGO_URI not set in .env file")
+
+# Configuration
+QDRANT_URL = "http://localhost:6333"
+COLLECTION_NAME = "metta_codebase"
+
+# Initialize clients
+qdrant_client = QdrantClient(url=QDRANT_URL, timeout=5)
+mongo_client = AsyncMongoClient(MONGO_URI)
+db = mongo_client["chunkDB"]
+chunks_collection = db.get_collection("chunks")
+model = SentenceTransformer('google/embeddinggemma-300m')
+
+# Async function to fetch chunks from MongoDB
+async def get_chunks(filter_query: dict = None, limit: int = 100) -> list:
+    filter_query = filter_query or {"source": "code", "isEmbedded": False}
+    cursor = chunks_collection.find(filter_query, {"_id": 0}).limit(limit)
+    return [doc async for doc in cursor]
+
+# Async function to update embedding status in MongoDB
+async def update_embedding_status(chunk_id: str, status: bool) -> int:
+    result = await chunks_collection.update_one(
+        {"chunkId": chunk_id},
+        {"$set": {"isEmbedded": status}}
+    )
+    return result.modified_count
+
+# Embedding and storage function
+async def embed_and_store():
+    try:
+        # Fetch unembedded chunks from MongoDB
+        chunks = await get_chunks()
+        if not chunks:
+            print("No unembedded chunks found.")
+            return
+
+        points = []
+        for chunk_data in chunks:
+            # Embed the chunk content
+            embedding = model.encode(chunk_data["chunk"]).tolist()
+            
+            # Prepare metadata (all ChunkSchema fields)
+            metadata = {
+                "chunkId": chunk_data["chunkId"],
+                "source": chunk_data["source"],
+                "chunk": chunk_data["chunk"],
+                "project": chunk_data["project"],
+                "repo": chunk_data["repo"],
+                "section": chunk_data["section"],
+                "file": chunk_data["file"],
+                "version": chunk_data["version"],
+                "isEmbedded": chunk_data["isEmbedded"]
+            }
+            
+            points.append(
+                PointStruct(
+                    id=str(uuid.uuid4()),  # Unique ID for Qdrant
+                    vector=embedding,
+                    payload=metadata
+                )
+            )
+        
+        # Upsert to Qdrant
+        qdrant_client.upsert(
+            collection_name=COLLECTION_NAME,
+            points=points
+        )
+        print(f"Stored {len(points)} chunks in {COLLECTION_NAME}")
+
+        # Update isEmbedded status in MongoDB
+        for chunk_data in chunks:
+            modified = await update_embedding_status(chunk_data["chunkId"], True)
+            if modified:
+                print(f"Updated isEmbedded to True for chunkId: {chunk_data['chunkId']}")
+
+    except Exception as e:
+        print("Failed to embed and store chunks:", str(e))
+
+# Run the pipeline
+if __name__ == "__main__":
+    asyncio.run(embed_and_store())

--- a/MeTTaCodeRetrieval/search_metta_code.py
+++ b/MeTTaCodeRetrieval/search_metta_code.py
@@ -1,0 +1,96 @@
+from qdrant_client import QdrantClient
+from qdrant_client.http.models import Filter, FieldCondition, MatchValue
+from sentence_transformers import SentenceTransformer
+
+# Configuration
+QDRANT_URL = "http://localhost:6333"
+COLLECTION_NAME = "metta_codebase"
+
+# Initialize clients
+client = QdrantClient(url=QDRANT_URL, timeout=5)
+model = SentenceTransformer('google/embeddinggemma-300m')
+
+# Search function
+def search_metta_code(query, repo_filter=None, source_filter=None, is_embedded_filter=None, limit=5):
+    try:
+        # Embed the query
+        query_vector = model.encode(query).tolist()
+
+        # Build metadata filter
+        filters = []
+        if repo_filter:
+            filters.append(
+                FieldCondition(
+                    key="repo",
+                    match=MatchValue(value=repo_filter)
+                )
+            )
+        if source_filter:
+            filters.append(
+                FieldCondition(
+                    key="source",
+                    match=MatchValue(value=source_filter)
+                )
+            )
+        if is_embedded_filter is not None:
+            filters.append(
+                FieldCondition(
+                    key="isEmbedded",
+                    match=MatchValue(value=is_embedded_filter)
+                )
+            )
+        
+        query_filter = Filter(must=filters) if filters else None
+
+        # Perform search
+        results = client.search(
+            collection_name=COLLECTION_NAME,
+            query_vector=query_vector,
+            query_filter=query_filter,
+            limit=limit
+        )
+
+        # Display results
+        print(f"\nSearch results for query: '{query}'")
+        for i, result in enumerate(results, 1):
+            print(f"\nResult {i}:")
+            print(f"Score: {result.score:.4f}")
+            print(f"Chunk ID: {result.payload['chunkId']}")
+            print(f"Chunk: {result.payload['chunk']}")
+            print(f"Source: {result.payload['source']}")
+            print(f"Project: {result.payload['project']}")
+            print(f"Repo: {result.payload['repo']}")
+            print(f"Section: {result.payload['section']}")
+            print(f"File: {result.payload['file']}")
+            print(f"Version: {result.payload['version']}")
+            print(f"Is Embedded: {result.payload['isEmbedded']}")
+            print("-" * 50)
+        
+        return results
+    
+    except Exception as e:
+        print("Search failed:", str(e))
+        return []
+
+# Example searches
+if __name__ == "__main__":
+    # Basic semantic search
+    search_metta_code("recursive function")
+    
+    # Search with repo filter
+    search_metta_code(
+        query="recursive function",
+        repo_filter="github.com/trueagi-io/hyperon-experimental"
+    )
+    
+    # Search for code chunks
+    search_metta_code(
+        query="graph relation",
+        source_filter="code"
+    )
+    
+    # Search for unembedded chunks (should be empty after embedding)
+    search_metta_code(
+        query="multivalued propagation",
+        is_embedded_filter=False
+    )


### PR DESCRIPTION
This PR introduces the MeTTaCodeRetrieval module to the larger project, enabling semantic and metadata-based retrieval of MeTTa code snippets. Key features:
- Retrieves unembedded chunks (isEmbedded: False) from MongoDB (chunkDB.chunks).
- Embeds chunks using google/embeddinggemma-300m (768-dim vectors) and stores them in Qdrant (metta_codebase).
- Updates isEmbedded to True to prevent re-embedding.
- Supports semantic searches (e.g., "recursive function") and metadata filters (e.g., repo="github.com/trueagi-io/hyperon-experimental", source="code").
- README.md documents functionality and technologies.