### PR TITLE
Fix/chat session issues

### DIFF
--- a/Backend/app/core/utils/helpers.py
+++ b/Backend/app/core/utils/helpers.py
@@ -5,7 +5,7 @@ from langchain.chat_models import init_chat_model
 
 def get_required_env(key: str, default: Any = None) -> str:
     value = os.getenv(key, default)
-    if not value:
+    if value is None:
         logger.error(f"Environment variable {key} is required")
         raise RuntimeError(f"Environment variable {key} is required")
     return value

--- a/Backend/app/rag/generator/rag_generator.py
+++ b/Backend/app/rag/generator/rag_generator.py
@@ -22,7 +22,7 @@ class RAGGenerator:
         query: str,
         top_k: int = 5,
         api_key: Optional[str] = None,
-        include_sources: bool = True,
+        include_sources: bool = False,
         history: Optional[List[Dict[str, str]]] = None,
     ) -> Dict[str, Any]:
         retrieved_docs = await self.retriever.retrieve(query, top_k=top_k)

--- a/Backend/app/routers/chat.py
+++ b/Backend/app/routers/chat.py
@@ -111,7 +111,7 @@ async def chat(
                 generator = RAGGenerator(
                     retriever=retriever, provider=provider_enum, model_name=model
                 )
-            await insert_chat_message(
+            user_message_id = await insert_chat_message(
                 {"sessionId": session_id, "role": "user", "content": query},
                 mongo_db=mongo_db,
             )
@@ -137,7 +137,7 @@ async def chat(
 
             response_id = f"resp_{ObjectId()}"
 
-            await insert_chat_message(
+            message_id = await insert_chat_message(
                 {
                     "sessionId": session_id,
                     "role": "assistant",
@@ -167,9 +167,9 @@ async def chat(
                 )
             except Exception:
                 logger.warning("Failed to log RAG interaction", exc_info=True)
-            if created_new_session:
-                result["session_id"] = session_id
-            
+            result["session_id"] = session_id
+            result["userMessageId"] = user_message_id
+            result["messageId"] = message_id
             result["responseId"] = response_id
             return result
     except Exception as e:

--- a/Backend/app/routers/chat.py
+++ b/Backend/app/routers/chat.py
@@ -128,11 +128,11 @@ async def chat(
             
             if encrypted_key and api_key:
                 result = await generator.generate_response(
-                    query, top_k=top_k,api_key=api_key, include_sources=True, history=history,
+                    query, top_k=top_k,api_key=api_key, include_sources=False, history=history,
                 )
             else:
                 result = await generator.generate_response(
-                    query, top_k=top_k, api_key=None, include_sources=True, history=history
+                    query, top_k=top_k, api_key=None, include_sources=False, history=history
                 )
 
             response_id = f"resp_{ObjectId()}"

--- a/Frontend/src/components/chat/MessageInput.tsx
+++ b/Frontend/src/components/chat/MessageInput.tsx
@@ -3,15 +3,16 @@ import { ArrowUp } from 'lucide-react'
 
 interface ChatInputProps {
   onSend: (text: string) => void
+  isSendingMessage?: boolean
   maxWidthClass?: string
 }
 
-function MessageInput({ onSend }: ChatInputProps) {
+function MessageInput({ onSend, isSendingMessage = false }: ChatInputProps) {
   const [text, setText] = useState('')
 
   function submit(e: React.FormEvent<HTMLFormElement>) {
     e.preventDefault()
-    if (!text.trim()) return
+    if (!text.trim() || isSendingMessage) return
     onSend(text)
     setText('')
   }
@@ -35,9 +36,9 @@ function MessageInput({ onSend }: ChatInputProps) {
           />
           <button
             type="submit"
-            disabled={!text.trim()}
+            disabled={!text.trim() || isSendingMessage}
             className="absolute right-3 top-1/2 -translate-y-1/2 p-2 rounded-lg bg-zinc-900 dark:bg-white text-white dark:text-black hover:bg-zinc-700 dark:hover:bg-zinc-200 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-            title="Send message"
+            title={isSendingMessage ? "Sending..." : "Send message"}
           >
             <ArrowUp className="w-4 h-4" />
           </button>

--- a/Frontend/src/pages/Chat.tsx
+++ b/Frontend/src/pages/Chat.tsx
@@ -14,7 +14,7 @@ function Chat() {
   const [settingsOpen, setSettingsOpen] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
-  const { messages, isLoadingMessages, sendMessage, selectedSessionId, updateMessageFeedback } = useChatStore();
+  const { messages, isLoadingMessages, isSendingMessage, sendMessage, selectedSessionId, updateMessageFeedback } = useChatStore();
 
   function handleSuggestionClick(text: string) {
     sendMessage(text);
@@ -118,7 +118,7 @@ function Chat() {
             onFeedback={handleFeedback}
           />
         )}
-        <MessageInput onSend={sendMessage} />
+        <MessageInput onSend={sendMessage} isSendingMessage={isSendingMessage} />
       </div>
       <SettingsModal isOpen={settingsOpen} onClose={() => setSettingsOpen(false)} />
     </div>

--- a/Frontend/src/services/chatService.ts
+++ b/Frontend/src/services/chatService.ts
@@ -18,8 +18,10 @@ export interface ChatResponse {
   response: string;
   model: string;
   provider: string;
-  session_id: string; // Assuming backend returns session_id
-  responseId?: string; // Backend response ID for feedback
+  session_id: string; 
+  responseId?: string; 
+  messageId?: string; 
+  userMessageId?: string; 
 }
 
 // Fetch paginated chat sessions

--- a/Frontend/src/store/useChatStore.ts
+++ b/Frontend/src/store/useChatStore.ts
@@ -20,6 +20,7 @@ interface ChatState {
   hasMoreSessions: boolean;
   isLoadingSessions: boolean;
   isLoadingMessages: boolean;
+  isSendingMessage: boolean;
   error: string | null;
 
   // Actions
@@ -41,6 +42,7 @@ const chatStoreCreator: StateCreator<ChatState> = (set, get) => ({
   hasMoreSessions: false,
   isLoadingSessions: false,
   isLoadingMessages: false,
+  isSendingMessage: false,
   error: null,
 
   loadSessions: async () => {
@@ -350,6 +352,13 @@ const chatStoreCreator: StateCreator<ChatState> = (set, get) => ({
       return;
     }
 
+    // Prevent sending if already sending a message
+    const { isSendingMessage } = get();
+    if (isSendingMessage) {
+      return;
+    }
+
+    set({ isSendingMessage: true });
     let { selectedSessionId } = get();
 
     // Optimistically show the user message and thinking message immediately
@@ -443,6 +452,7 @@ const chatStoreCreator: StateCreator<ChatState> = (set, get) => ({
       // Ensure selectedSessionId is updated to the real backend id
       set((state) => ({
         selectedSessionId: realSessionId,
+        isSendingMessage: false,
       }));
     } catch (err: any) {
       if (err?.response?.status === 401) {
@@ -510,6 +520,7 @@ const chatStoreCreator: StateCreator<ChatState> = (set, get) => ({
 
           set((state) => ({
             selectedSessionId: realSessionId,
+            isSendingMessage: false,
           }));
           return;
         } catch (refreshErr) {
@@ -527,6 +538,7 @@ const chatStoreCreator: StateCreator<ChatState> = (set, get) => ({
       };
       set((state) => ({
         messages: state.messages.map((msg) => (msg.id === thinkingMessage.id ? errorMessage : msg)),
+        isSendingMessage: false,
       }));
     }
   },


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes critical session fragmentation issues where chat sessions were splitting into separate sessions both on page refresh and even within a single conversation. The root cause was that the backend only returned session_id when creating new sessions, causing the frontend to lose track of the current session and create new ones for subsequent messages. Additionally, message IDs were being generated inconsistently by concatenating query text with timestamps, resulting in messy IDs like "hello1764680473324". The fix ensures the backend always returns session_id in every response and captures both userMessageId and messageId from the database for proper ID management. On the frontend, we now use these backend-generated IDs instead of client-side generation, and added session persistence via Zustand middleware to store sessions and selectedSessionId in localStorage (messages are fetched fresh from the database). This results in sessions persisting across page refreshes, eliminates session fragmentation, and provides clean, database-backed message IDs for reliable feedback tracking.

This PR also makes the button in the frontend disabled when waiting for the respose from thee llm.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Code cleanup

## Checklist
- [x] I have read the contributing guidelines
- [ ] I have added or updated tests where applicable
- [ ] I have added or updated documentation where applicable
- [x] I have reviewed and tested my changes, and I have run the code to confirm it works properly

## How Has This Been Tested?
Manually



