### PR TITLE
feat: implement the rewriter for the retriever

### DIFF
--- a/Backend/app/core/utils/rewriter_utils.py
+++ b/Backend/app/core/utils/rewriter_utils.py
@@ -1,0 +1,38 @@
+class RewriterUtils:
+    @staticmethod
+    def rewrite_query(query: str, history) -> str:
+        return f"""
+You are Metta AI Assistant, an intelligent assistant designed to accelerate the development and adoption of the MeTTa programming language—central to the Hyperon framework for AGI. Your primary role is to help developers write, understand, and translate MeTTa code using your knowledge base.
+You are a query-rewriting assistant for a retrieval system.
+Your job is to decide whether the user query requires retrieval, and to produce a rewritten query if needed.
+
+INSTRUCTIONS:
+1. You MUST return ONLY a valid JSON object. Do not add any markdown formatting, code blocks, or explanations.
+2. Determine if the user query needs retrieval from a knowledge base:
+   - "retriever_needed": true -> if the query asks for information, facts, or is complex.
+   - "retriever_needed": false -> if the query is a greeting, small talk, or a simple thank you.
+3. If the question is unrelated to MeTTa, Hyperon, or AGI, politely say you can only answer MeTTa/Hyperon questions.
+FORMAT:
+{{
+  "retriever_needed": boolean,
+  "query": "string"
+}}
+
+EXAMPLES:
+
+User: "Hi"
+Output: {{ "retriever_needed": false, "query": "Hello! How can I assist you today?" }}
+
+User: "What does this code do?" (with conversation context about a specific function)
+Output: {{ "retriever_needed": true, "query": "explanation of the function discussed in context" }}
+
+User: "Thanks"
+Output: {{ "retriever_needed": false, "query": "You're welcome!" }}
+
+User: "How do I configure the database?"
+Output: {{ "retriever_needed": true, "query": "configure database settings" }}
+
+CURRENT CONTEXT:
+User Query: "{query}"
+History: "{history}"
+"""

--- a/Backend/app/rag/generator/rag_generator.py
+++ b/Backend/app/rag/generator/rag_generator.py
@@ -35,9 +35,9 @@ class RAGGenerator:
 
         try:
             rewritten_query = json.loads(cleaned_query_str)
-            logger.info(f"Rewritten query: {rewritten_query}")
+            logger.info("Rewritten query: %s", rewritten_query)
         except json.JSONDecodeError:
-            logger.warning(f"Failed to parse rewritten query JSON: {cleaned_query_str}")
+            logger.warning("Failed to parse rewritten query JSON: %s", cleaned_query_str)
             rewritten_query = {"retriever_needed": True, "query": query}
 
         if rewritten_query.get("retriever_needed"):


### PR DESCRIPTION
# Pull Request

## Description
I have implemented the rewriter for the retriever if needed like context addition. If it is not needed, it will simply return the original query. And if the query is greeting or small talk it will answer it in one call and make the retriever needed false.

## Type of Change
- [X] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Code cleanup

## Checklist
- [X] I have read the contributing guidelines
- [ ] I have added or updated tests where applicable
- [ ] I have added or updated documentation where applicable
- [X] I have reviewed and tested my changes, and I have run the code to confirm it works properly

## How Has This Been Tested?
Greeting Test: Sent "Hi" to the chat. Verified in logs that retriever_needed was false and the retriever was NOT called.
Complex Query Test: Sent "What is MeTTa?". Verified that retriever_needed was true, the rewritten query is returned and search results were retrieved.

## Additional Notes
Add any additional context or information about the pull request here.

