### PR TITLE
feat(chat): implement cursor-based pagination for messages

### DIFF
--- a/Frontend/src/components/chat/MessageList.tsx
+++ b/Frontend/src/components/chat/MessageList.tsx
@@ -1,45 +1,109 @@
-import { useEffect, useRef } from 'react'
-import type { Message, SuggestionCard } from '../../types'
-import ChatMessageItem from './MessageBubble'
+import { useEffect, useRef } from "react";
+import type { Message, SuggestionCard } from "../../types";
+import ChatMessageItem from "./MessageBubble";
 
 interface ChatMessageListProps {
-  messages: Message[]
-  onSuggestionClick: (text: string) => void
-  onFeedback?: (messageId: string, feedback: 'positive' | 'neutral' | 'negative') => void
+  messages: Message[];
+  onSuggestionClick: (text: string) => void;
+  onFeedback?: (
+    messageId: string,
+    feedback: "positive" | "neutral" | "negative"
+  ) => void;
+  onLoadOlder?: () => Promise<number>;
+  hasNextMessages?: boolean;
+  isLoadingMoreMessages?: boolean;
 }
 
 const suggestionCards: SuggestionCard[] = [
-  { title: 'What is MeTTa?', subtitle: 'Explain the basics' },
-  { title: 'Pattern matching', subtitle: 'How does it work in MeTTa?' },
-  { title: 'Type system', subtitle: 'MeTTa type checking explained' },
-  { title: 'Symbolic reasoning', subtitle: 'Combining with neural networks' },
-]
+  { title: "What is MeTTa?", subtitle: "Explain the basics" },
+  { title: "Pattern matching", subtitle: "How does it work in MeTTa?" },
+  { title: "Type system", subtitle: "MeTTa type checking explained" },
+  { title: "Symbolic reasoning", subtitle: "Combining with neural networks" },
+];
 
-function MessageList({ messages, onSuggestionClick, onFeedback }: ChatMessageListProps) {
-  const showWelcome = messages.length === 0
-  const messagesEndRef = useRef<HTMLDivElement>(null)
+function MessageList({
+  messages,
+  onSuggestionClick,
+  onFeedback,
+  onLoadOlder,
+  hasNextMessages = false,
+  isLoadingMoreMessages = false,
+}: ChatMessageListProps) {
+  const showWelcome = messages.length === 0;
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const isFetchingRef = useRef(false);
 
   // Auto-scroll to bottom when messages change
   useEffect(() => {
-    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' })
-  }, [messages])
+    if (isLoadingMoreMessages) return;
+    messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, isLoadingMoreMessages]);
+
+  async function handleScroll() {
+    const container = containerRef.current;
+    if (
+      !container ||
+      !hasNextMessages ||
+      !onLoadOlder ||
+      isLoadingMoreMessages ||
+      isFetchingRef.current
+    ) {
+      return;
+    }
+
+    const threshold = 24;
+    if (container.scrollTop <= threshold) {
+      isFetchingRef.current = true;
+      const prevHeight = container.scrollHeight;
+      const prevTop = container.scrollTop;
+      try {
+        const added = await onLoadOlder();
+        requestAnimationFrame(() => {
+          const nextHeight = container.scrollHeight;
+          const delta = nextHeight - prevHeight;
+          container.scrollTop = prevTop + delta;
+        });
+        if (added === 0) {
+          isFetchingRef.current = false;
+        }
+      } finally {
+        isFetchingRef.current = false;
+      }
+    }
+  }
 
   return (
-    <div className="flex-1 overflow-y-auto overflow-x-hidden px-4 py-8" style={{ scrollbarWidth: 'thin' }}>
+    <div
+      ref={containerRef}
+      className="flex-1 overflow-y-auto overflow-x-hidden px-4 py-8"
+      style={{ scrollbarWidth: "thin" }}
+      onScroll={handleScroll}
+    >
       <div className="mx-auto max-w-2xl">
         {showWelcome ? (
           <div className="flex flex-col items-center justify-center min-h-[60vh]">
-            <h1 className="text-3xl font-semibold mb-1.5">What's on your mind today?</h1>
-            <p className="text-gray-500 dark:text-gray-400 mb-8 text-sm">Start a conversation with MeTTa AI</p>
+            <h1 className="text-3xl font-semibold mb-1.5">
+              What's on your mind today?
+            </h1>
+            <p className="text-gray-500 dark:text-gray-400 mb-8 text-sm">
+              Start a conversation with MeTTa AI
+            </p>
             <div className="grid grid-cols-1 md:grid-cols-2 gap-2.5 w-full max-w-2xl">
               {suggestionCards.map((card) => (
                 <button
                   key={card.title}
-                  onClick={() => onSuggestionClick(`${card.title} ${card.subtitle}`)}
+                  onClick={() =>
+                    onSuggestionClick(`${card.title} ${card.subtitle}`)
+                  }
                   className="text-left p-3 rounded-xl border border-gray-200 dark:border-gray-700 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors group"
                 >
-                  <div className="font-medium text-xs mb-0.5 group-hover:text-gray-900 dark:group-hover:text-white transition-colors">{card.title}</div>
-                  <div className="text-[10px] text-gray-500 dark:text-gray-400">{card.subtitle}</div>
+                  <div className="font-medium text-xs mb-0.5 group-hover:text-gray-900 dark:group-hover:text-white transition-colors">
+                    {card.title}
+                  </div>
+                  <div className="text-[10px] text-gray-500 dark:text-gray-400">
+                    {card.subtitle}
+                  </div>
                 </button>
               ))}
             </div>
@@ -54,7 +118,7 @@ function MessageList({ messages, onSuggestionClick, onFeedback }: ChatMessageLis
         )}
       </div>
     </div>
-  )
+  );
 }
 
-export default MessageList
+export default MessageList;

--- a/Frontend/src/components/chat/MessageList.tsx
+++ b/Frontend/src/components/chat/MessageList.tsx
@@ -64,9 +64,6 @@ function MessageList({
           const delta = nextHeight - prevHeight;
           container.scrollTop = prevTop + delta;
         });
-        if (added === 0) {
-          isFetchingRef.current = false;
-        }
       } finally {
         isFetchingRef.current = false;
       }

--- a/Frontend/src/pages/Chat.tsx
+++ b/Frontend/src/pages/Chat.tsx
@@ -1,36 +1,54 @@
-import { useState, useEffect } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
-import ChatHeader from '../components/chat/ChatHeader';
-import MessageList from '../components/chat/MessageList';
-import MessageInput from '../components/chat/MessageInput';
-import Sidebar from '../components/Sidebar';
-import SettingsModal from '../components/modals/SettingsModal';
-import { useChatStore } from '../store/useChatStore';
-import { isAuthenticated } from '../lib/auth';
-import { submitFeedback } from '../services/chatService';
+import { useState, useEffect } from "react";
+import { useNavigate, useLocation } from "react-router-dom";
+import ChatHeader from "../components/chat/ChatHeader";
+import MessageList from "../components/chat/MessageList";
+import MessageInput from "../components/chat/MessageInput";
+import Sidebar from "../components/Sidebar";
+import SettingsModal from "../components/modals/SettingsModal";
+import { useChatStore } from "../store/useChatStore";
+import { isAuthenticated } from "../lib/auth";
+import { submitFeedback } from "../services/chatService";
 
 function Chat() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
-  const { messages, isLoadingMessages, isSendingMessage, sendMessage, selectedSessionId, updateMessageFeedback } = useChatStore();
+  const {
+    messages,
+    isLoadingMessages,
+    isSendingMessage,
+    sendMessage,
+    selectedSessionId,
+    updateMessageFeedback,
+    loadOlderMessages,
+    hasNextMessages,
+    isLoadingMoreMessages,
+  } = useChatStore();
 
   function handleSuggestionClick(text: string) {
     sendMessage(text);
   }
 
-  async function handleFeedback(messageId: string, feedback: 'positive' | 'neutral' | 'negative') {
-    const message = messages.find(m => m.id === messageId);
+  async function handleFeedback(
+    messageId: string,
+    feedback: "positive" | "neutral" | "negative"
+  ) {
+    const message = messages.find((m) => m.id === messageId);
     if (!message || !message.responseId || !selectedSessionId) {
-      console.error('Cannot submit feedback: missing responseId or sessionId');
+      console.error("Cannot submit feedback: missing responseId or sessionId");
       return;
     }
 
     const previousFeedback = message.feedback;
 
     try {
-      console.log('[Chat] handleFeedback called:', { messageId, feedback, responseId: message.responseId, sessionId: selectedSessionId });
+      console.log("[Chat] handleFeedback called:", {
+        messageId,
+        feedback,
+        responseId: message.responseId,
+        sessionId: selectedSessionId,
+      });
 
       // Update local state immediately for better UX
       updateMessageFeedback(messageId, feedback);
@@ -41,9 +59,9 @@ function Chat() {
         sessionId: selectedSessionId,
         sentiment: feedback,
       });
-      console.log('[Chat] Feedback submitted successfully');
+      console.log("[Chat] Feedback submitted successfully");
     } catch (error) {
-      console.error('[Chat] Failed to submit feedback:', error);
+      console.error("[Chat] Failed to submit feedback:", error);
       // Revert optimistic update on error
       updateMessageFeedback(messageId, previousFeedback || null);
     }
@@ -60,14 +78,14 @@ function Chat() {
     };
 
     handleResize();
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, []);
 
   // Auth guard: redirect to /login if not authenticated
   useEffect(() => {
-    if (!isAuthenticated() && location.pathname !== '/login') {
-      navigate('/login');
+    if (!isAuthenticated() && location.pathname !== "/login") {
+      navigate("/login");
     }
   }, [location.pathname, navigate]);
 
@@ -79,10 +97,7 @@ function Chat() {
   return (
     <div className="flex h-screen bg-white dark:bg-black overflow-hidden">
       {/* Left panel: sidebar */}
-      <Sidebar
-        isOpen={sidebarOpen}
-        onClose={() => setSidebarOpen(false)}
-      />
+      <Sidebar isOpen={sidebarOpen} onClose={() => setSidebarOpen(false)} />
 
       {/* Right panel: chat window */}
       <div className="flex-1 flex flex-col overflow-hidden">
@@ -91,7 +106,10 @@ function Chat() {
           onOpenSettings={() => setSettingsOpen(true)}
         />
         {isLoadingMessages ? (
-          <div className="flex-1 overflow-y-auto px-4 py-8" style={{ scrollbarWidth: 'thin' }}>
+          <div
+            className="flex-1 overflow-y-auto px-4 py-8"
+            style={{ scrollbarWidth: "thin" }}
+          >
             <div className="mx-auto max-w-2xl space-y-4">
               {/* Skeleton bubbles mimicking chat messages, starting near the top and biased to the right */}
               <div className="flex justify-end mt-1">
@@ -116,14 +134,22 @@ function Chat() {
             messages={messages}
             onSuggestionClick={handleSuggestionClick}
             onFeedback={handleFeedback}
+            onLoadOlder={loadOlderMessages}
+            hasNextMessages={hasNextMessages}
+            isLoadingMoreMessages={isLoadingMoreMessages}
           />
         )}
-        <MessageInput onSend={sendMessage} isSendingMessage={isSendingMessage} />
+        <MessageInput
+          onSend={sendMessage}
+          isSendingMessage={isSendingMessage}
+        />
       </div>
-      <SettingsModal isOpen={settingsOpen} onClose={() => setSettingsOpen(false)} />
+      <SettingsModal
+        isOpen={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+      />
     </div>
   );
 }
 
-export default Chat
-
+export default Chat;

--- a/Frontend/src/services/chatService.ts
+++ b/Frontend/src/services/chatService.ts
@@ -1,5 +1,5 @@
 import axiosInstance, { handleAxiosError } from '../lib/axios';
-import type { ChatSession, SessionsResponse, Message, ChatSessionWithMessages } from '../types/chat';
+import type { ChatSession, SessionsResponse, Message, ChatSessionWithMessages, CursorMessagesResponse } from '../types/chat';
 
 const SESSIONS_BASE_URL = '/api/chat/sessions';
 const CHAT_BASE_URL = '/api/chat';
@@ -42,6 +42,23 @@ export const getSessionMessages = async (sessionId: string): Promise<Message[]> 
   try {
     const response = await axiosInstance.get<ChatSessionWithMessages>(`${SESSIONS_BASE_URL}/${sessionId}`);
     return response.data.messages || [];
+  } catch (error) {
+    handleAxiosError(error, 'Sessions');
+    throw error;
+  }
+};
+
+// Cursor-based message retrieval
+export const getSessionMessagesCursor = async (
+  sessionId: string,
+  limit: number = 5,
+  cursor?: string
+): Promise<CursorMessagesResponse> => {
+  try {
+    const response = await axiosInstance.get<CursorMessagesResponse>(`${SESSIONS_BASE_URL}/${sessionId}/messages`, {
+      params: { limit, cursor },
+    });
+    return response.data;
   } catch (error) {
     handleAxiosError(error, 'Sessions');
     throw error;

--- a/Frontend/src/services/chatService.ts
+++ b/Frontend/src/services/chatService.ts
@@ -48,6 +48,20 @@ export const getSessionMessages = async (sessionId: string): Promise<Message[]> 
   }
 };
 
+export interface FirstUserMessageResponse {
+  message: { messageId: string; content: string; createdAt: string } | null;
+}
+
+export const getFirstUserMessage = async (sessionId: string): Promise<FirstUserMessageResponse> => {
+  try {
+    const response = await axiosInstance.get<FirstUserMessageResponse>(`${SESSIONS_BASE_URL}/${sessionId}/first-user-message`);
+    return response.data;
+  } catch (error) {
+    handleAxiosError(error, 'Sessions');
+    throw error;
+  }
+};
+
 // Delete a chat session
 export const deleteChatSession = async (sessionId: string): Promise<void> => {
   try {

--- a/Frontend/src/services/chatService.ts
+++ b/Frontend/src/services/chatService.ts
@@ -51,7 +51,7 @@ export const getSessionMessages = async (sessionId: string): Promise<Message[]> 
 // Cursor-based message retrieval
 export const getSessionMessagesCursor = async (
   sessionId: string,
-  limit: number = 5,
+  limit: number = 10,
   cursor?: string
 ): Promise<CursorMessagesResponse> => {
   try {

--- a/Frontend/src/types/chat.ts
+++ b/Frontend/src/types/chat.ts
@@ -28,3 +28,9 @@ export interface SessionsResponse {
   has_next: boolean;
   has_prev: boolean;
 }
+
+export interface CursorMessagesResponse {
+  messages: Message[];
+  nextCursor: string | null;
+  hasNext: boolean;
+}


### PR DESCRIPTION
# Pull Request

## Description
Implements cursor-based pagination for chat messages to improve performance with large histories. Replaces full-load with batched retrieval and adds infinite scroll to fetch older messages on demand.
## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Code cleanup

## Checklist
-  [x] I have read the contributing guidelines
- [ ] I have added or updated tests where applicable
- [ ] I have added or updated documentation where applicable
- [x] I have reviewed and tested my changes, and I have run the code to confirm it works properly

## How Has This Been Tested?
Verified with 60+ messages; infinite scroll loads older batches at page top; next cursor and hasNext behave correctly.
