### PR TITLE
Fix: Improve Chat History Recall

### DIFF
--- a/Backend/app/core/middleware.py
+++ b/Backend/app/core/middleware.py
@@ -114,7 +114,7 @@ class UserWindowRateLimiter(BaseHTTPMiddleware):
             try:
                 decrypted = await kms.decrypt_api_key(gemini_cookie, user_id, "gemini", mongo_db)
                 if decrypted and decrypted.strip():
-                    logger.debug(f"Valid gemini API key for user {user_id}")
+                    logger.info(f"Valid gemini API key for user {user_id}")
                     return True
             except Exception as e:
                 logger.warning(f"Invalid gemini cookie for user {user_id}: {e}")
@@ -124,7 +124,7 @@ class UserWindowRateLimiter(BaseHTTPMiddleware):
             try:
                 decrypted = await kms.decrypt_api_key(openai_cookie, user_id, "openai", mongo_db)
                 if decrypted and decrypted.strip():
-                    logger.debug(f"Valid openai API key for user {user_id}")
+                    logger.info(f"Valid openai API key for user {user_id}")
                     return True
             except Exception as e:
                 logger.warning(f"Invalid openai cookie for user {user_id}: {e}")
@@ -148,15 +148,15 @@ class UserWindowRateLimiter(BaseHTTPMiddleware):
 
         if await self._is_using_user_api_key(request, user_id):
             
-            logger.debug(f"Rate limiting skipped for user {user_id} - using own API key")
+            logger.info(f"Rate limiting skipped for user {user_id} - using own API key")
             
             return await call_next(request)
 
         if user_role != "user":
-            logger.debug(f"Rate limiting skipped for user {user_id} - not a regular user")
+            logger.info(f"Rate limiting skipped for user {user_id} - not a regular user")
             return await call_next(request)
         
-        logger.debug(f"Rate limiting applied for user {user_id} - using system API key")
+        logger.info(f"Rate limiting applied for user {user_id} - using system API key")
 
         redis_key = f"ratelimit:fixed{self.window_seconds}s:{user_id}"
 

--- a/Backend/app/db/db.py
+++ b/Backend/app/db/db.py
@@ -4,7 +4,6 @@ from pymongo.errors import BulkWriteError
 from pymongo.database import Database
 from pymongo.collection import Collection
 from app.core.logging import logger
-from typing import Union, List
 from app.model.chunk import ChunkSchema
 
 

--- a/Backend/app/dependencies.py
+++ b/Backend/app/dependencies.py
@@ -7,6 +7,7 @@ from app.core.clients.llm_clients import LLMClient
 from app.repositories.chunk_repository import ChunkRepository
 from app.services.chunk_annotation_service import ChunkAnnotationService
 from app.services.key_management_service import KMS
+from app.services.chat_service import ChatService
 from app.db.users import UserRole
 
 
@@ -50,6 +51,23 @@ def get_annotation_service(
 def get_kms(request: Request) -> KMS:
     '''Key management service class dependency'''
     return request.app.state.kms
+
+
+def get_chat_service(
+    mongo_db=Depends(get_mongo_db),
+    embedding_model=Depends(get_embedding_model_dep),
+    qdrant_client=Depends(get_qdrant_client_dep),
+    default_llm=Depends(get_llm_provider_dep),
+    kms=Depends(get_kms),
+) -> ChatService:
+    """Provide ChatService instance with all required dependencies."""
+    return ChatService(
+        mongo_db=mongo_db,
+        embedding_model=embedding_model,
+        qdrant_client=qdrant_client,
+        default_llm_client=default_llm,
+        kms=kms,
+    )
 
 
 def get_current_user(request: Request) -> dict:

--- a/Backend/app/repositories/constants.py
+++ b/Backend/app/repositories/constants.py
@@ -1,0 +1,8 @@
+class MongoFields:
+    CHUNK_ID = "chunkId"
+    DESCRIPTION = "description"
+    STATUS = "status"
+    SOURCE = "source"
+    LAST_ANNOTATED_AT = "last_annotated_at"
+    PENDING_SINCE = "pending_since"
+    RETRY_COUNT = "retry_count"

--- a/Backend/app/routers/chat.py
+++ b/Backend/app/routers/chat.py
@@ -74,4 +74,4 @@ async def chat(
         
     except Exception as e:
         logger.error(f"Chat request failed: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Chat failed: {str(e)}")
+        raise HTTPException(status_code=500, detail=f"Chat failed: Retry later")

--- a/Backend/app/routers/chat.py
+++ b/Backend/app/routers/chat.py
@@ -1,24 +1,10 @@
-import os
-import time
 from typing import Optional, Literal
 from datetime import datetime, timedelta, timezone
 from pydantic import BaseModel, Field
 from fastapi import APIRouter, HTTPException, Depends, Request, Response
-from bson import ObjectId
-from app.dependencies import (
-    get_embedding_model_dep,
-    get_qdrant_client_dep,
-    get_llm_provider_dep,
-    get_mongo_db,
-    get_kms,
-    get_current_user
-)
-from app.rag.retriever.retriever import EmbeddingRetriever
-from app.core.clients.llm_clients import LLMProvider
-from app.rag.generator.rag_generator import RAGGenerator
-from app.db.chat_db import insert_chat_message, get_last_messages, create_chat_session
-from app.rag.rag_logging import log_rag_interaction
 
+from app.dependencies import get_chat_service, get_current_user
+from app.services.chat_service import ChatService
 from app.core.logging import logger
 
 router = APIRouter(
@@ -39,138 +25,53 @@ class ChatRequest(BaseModel):
 @router.post("/", summary="Chat with RAG system")
 async def chat(
     request: Request,
-    response: Response, 
+    response: Response,
     chat_request: ChatRequest,
-    model_dep=Depends(get_embedding_model_dep),
-    qdrant=Depends(get_qdrant_client_dep),
-    default_llm=Depends(get_llm_provider_dep),
-    mongo_db=Depends(get_mongo_db),
-    current_user = Depends(get_current_user),
-    kms = Depends(get_kms)
+    chat_service: ChatService = Depends(get_chat_service),
+    current_user: dict = Depends(get_current_user),
 ):
-
-
-    start_time = time.time()
-    query, provider, model = (
-        chat_request.query,
-        chat_request.provider,
-        chat_request.model,
-    )
-
-    mode, top_k = chat_request.mode, chat_request.top_k
-    session_id = chat_request.session_id
-    created_new_session = False
-    if not session_id:
-        session_id = await create_chat_session(current_user["id"],mongo_db=mongo_db)
-        created_new_session = True
-    collection_name = os.getenv("COLLECTION_NAME")
-    if not collection_name:
-        raise HTTPException(status_code=500, detail="COLLECTION_NAME not set")
+    """
+    Chat endpoint that handles both search and generate modes.
+    
+    - Decrypts user API keys from cookies if provided
+    - Creates or uses existing chat session
+    - Performs semantic search or generates RAG response
+    - Refreshes cookie expiration on successful key usage
+    """
+    provider = chat_request.provider
     
     if not provider:
         raise HTTPException(status_code=400, detail="Provider must be specified")
-    # Extract cookies
+    
+    # Extract encrypted API key from cookie
     encrypted_key = request.cookies.get(provider.lower())
-    api_key = ""
-
-    if encrypted_key and encrypted_key.strip():
-        try:
-            api_key = await kms.decrypt_api_key(encrypted_key, current_user["id"], provider.lower(), mongo_db)
-            
-            # Validate decrypted key is not empty
-            if not api_key or not api_key.strip():
-                logger.warning(f"Decrypted API key is empty for user {current_user['id']}, provider {provider}")
-                api_key = ""
-            else:
-                # refresh encrypted_api_key expiry date | sliding expiration refresh
-                response.set_cookie(
-                    key=provider.lower(), 
-                    value=encrypted_key, 
-                    httponly=True, 
-                    samesite="none",
-                    secure=True,
-                    expires=(datetime.now(timezone.utc) + timedelta(days=7))
-                )
-        except Exception as e:
-            logger.warning(f"Failed to decrypt API key cookie for user {current_user['id']}, provider {provider}: {e}")
-            api_key = ""
     
     try:
-        retriever = EmbeddingRetriever(
-            model=model_dep, qdrant=qdrant, collection_name=collection_name
+        # Process chat request through service
+        result = await chat_service.process_chat_request(
+            query=chat_request.query,
+            user_id=current_user["id"],
+            provider=provider,
+            mode=chat_request.mode,
+            model=chat_request.model,
+            session_id=chat_request.session_id,
+            encrypted_api_key=encrypted_key,
+            top_k=chat_request.top_k,
         )
-        if mode == "search":
-            results = await retriever.retrieve(query, top_k=top_k)
-            return {"query": query, "mode": "search", "results": results}
-        else:
-            if provider.lower() == "gemini" and not model:
-                generator = RAGGenerator(retriever=retriever, llm_client=default_llm)
-            else:
-                provider_enum = LLMProvider(provider.lower())
-                generator = RAGGenerator(
-                    retriever=retriever, provider=provider_enum, model_name=model
-                )
-            user_message_id = await insert_chat_message(
-                {"sessionId": session_id, "role": "user", "content": query},
-                mongo_db=mongo_db,
+        
+        # Refresh cookie expiration if user provided valid API key
+        if encrypted_key and encrypted_key.strip():
+            response.set_cookie(
+                key=provider.lower(),
+                value=encrypted_key,
+                httponly=True,
+                samesite="none",
+                secure=True,
+                expires=(datetime.now(timezone.utc) + timedelta(days=7)),
             )
-
-            raw_history = await get_last_messages(
-                session_id=session_id, limit=11, mongo_db=mongo_db
-            )
-            raw_history = raw_history[:-1] if raw_history else raw_history
-
-            history = [
-                {"role": m.get("role"), "content": m.get("content", "")}
-                for m in raw_history
-            ]
-            
-            if encrypted_key and api_key:
-                result = await generator.generate_response(
-                    query, top_k=top_k,api_key=api_key, include_sources=True, history=history,
-                )
-            else:
-                result = await generator.generate_response(
-                    query, top_k=top_k, api_key=None, include_sources=True, history=history
-                )
-
-            response_id = f"resp_{ObjectId()}"
-
-            message_id = await insert_chat_message(
-                {
-                    "sessionId": session_id,
-                    "role": "assistant",
-                    "content": result.get("response", ""),
-                    "responseId": response_id,
-                },
-                mongo_db=mongo_db,
-            )
-            try:
-                sources = result.get("sources", []) or []
-                contexts = [str(s.get("text", "")) for s in sources]
-                execution_time = time.time() - start_time
-                await log_rag_interaction(
-                    {
-                        "question": query,
-                        "answer": result.get("response", ""),
-                        "contexts": contexts,
-                        "metadata": {
-                            "session_id": session_id,
-                            "provider": provider,
-                            "model": model if model else "system",
-                            "response_id": response_id,
-                            "execution_time_seconds": execution_time
-                        },
-                    },
-                    mongo_db=mongo_db
-                )
-            except Exception:
-                logger.warning("Failed to log RAG interaction", exc_info=True)
-            result.pop("sources")
-            result["session_id"] = session_id
-            result["userMessageId"] = user_message_id
-            result["messageId"] = message_id
-            result["responseId"] = response_id
-            return result
+        
+        return result
+        
     except Exception as e:
+        logger.error(f"Chat request failed: {str(e)}", exc_info=True)
         raise HTTPException(status_code=500, detail=f"Chat failed: {str(e)}")

--- a/Backend/app/routers/chat.py
+++ b/Backend/app/routers/chat.py
@@ -116,7 +116,7 @@ async def chat(
             )
 
             raw_history = await get_last_messages(
-                session_id=session_id, limit=5, mongo_db=mongo_db
+                session_id=session_id, limit=11, mongo_db=mongo_db
             )
             raw_history = raw_history[:-1] if raw_history else raw_history
 

--- a/Backend/app/routers/chat_sessions.py
+++ b/Backend/app/routers/chat_sessions.py
@@ -15,6 +15,8 @@ from app.model.chat_session import (
     ChatSessionWithMessages
 )
 
+from app.core.logging import logger
+
 router = APIRouter(
     prefix="/api/chat/sessions",
     tags=["chat_sessions"],
@@ -40,9 +42,10 @@ async def list_sessions(
         )
         return result
     except Exception as e:
+        logger.error(f"Error retrieving sessions: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error retrieving sessions: {str(e)}",
+            detail="Error retrieving sessions.",
         )
 
 
@@ -141,7 +144,8 @@ async def delete_session(
     except HTTPException:
         raise
     except Exception as e:
+        logger.error(f"Error deleting session: {str(e)}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=f"Error deleting session: {str(e)}",
+            detail="Error deleting session.",
         )

--- a/Backend/app/routers/feedback.py
+++ b/Backend/app/routers/feedback.py
@@ -69,7 +69,7 @@ async def submit_feedback(
         logger.error(f"Error submitting feedback: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="Error submitting feedback.",
         )
 
 
@@ -93,7 +93,7 @@ async def get_feedback_for_response(
         logger.error(f"Error retrieving feedback: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="Error retrieving feedback.",
         )
 
 
@@ -113,5 +113,5 @@ async def get_stats(
         logger.error(f"Error getting stats: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e)
+            detail="Error getting stats.",
         )

--- a/Backend/app/routers/key_management.py
+++ b/Backend/app/routers/key_management.py
@@ -6,6 +6,7 @@ from app.dependencies import get_mongo_db, get_kms, get_current_user
 from app.model.key import APIKeyIn
 from app.services.key_management_service import KMS
 from app.core.utils.helpers import validate_api_key
+from app.core.logging import logger
 
 router = APIRouter(
     prefix="/api/kms",
@@ -27,7 +28,8 @@ async def store_api_key(
     try:
         await validate_api_key(payload.provider_name, payload.api_key)
     except Exception as e:
-        raise HTTPException(status_code=400, detail=f"Invalid API Key: {str(e)}")
+        logger.error(f"Invalid API Key: {str(e)}")
+        raise HTTPException(status_code=400, detail="Invalid API Key.")
 
     try:
         generated, encrypted_api_key = await kms.encrypt_and_store(

--- a/Backend/app/services/chat_service.py
+++ b/Backend/app/services/chat_service.py
@@ -1,0 +1,343 @@
+"""
+Chat Service - Handles all business logic for chat operations.
+
+This service orchestrates:
+- API key decryption and validation
+- RAG pipeline (retrieval and generation)
+- Message persistence
+- Chat history management
+- RAG interaction logging
+"""
+import os
+import time
+from typing import Optional, Dict, Any, List, Literal
+from datetime import datetime, timedelta, timezone
+from bson import ObjectId
+from pymongo.database import Database
+from sentence_transformers import SentenceTransformer
+from qdrant_client import AsyncQdrantClient
+
+from app.core.logging import logger
+from app.core.clients.llm_clients import LLMClient, LLMProvider
+from app.services.key_management_service import KMS
+from app.rag.retriever.retriever import EmbeddingRetriever
+from app.rag.generator.rag_generator import RAGGenerator
+from app.db.chat_db import insert_chat_message, get_last_messages, create_chat_session
+from app.rag.rag_logging import log_rag_interaction
+
+
+class ChatService:
+    """Service for handling chat operations with RAG system."""
+
+    def __init__(
+        self,
+        mongo_db: Database,
+        embedding_model: SentenceTransformer,
+        qdrant_client: AsyncQdrantClient,
+        default_llm_client: LLMClient,
+        kms: KMS,
+    ):
+        self.mongo_db = mongo_db
+        self.embedding_model = embedding_model
+        self.qdrant_client = qdrant_client
+        self.default_llm_client = default_llm_client
+        self.kms = kms
+        self.collection_name = os.getenv("COLLECTION_NAME")
+        
+        if not self.collection_name:
+            raise ValueError("COLLECTION_NAME environment variable not set")
+
+    async def decrypt_api_key(
+        self,
+        encrypted_key: Optional[str],
+        user_id: str,
+        provider: str,
+    ) -> str:
+        """
+        Decrypt and validate API key from cookie.
+        
+        Returns:
+            Decrypted API key or empty string if invalid/missing
+        """
+        if not encrypted_key or not encrypted_key.strip():
+            return ""
+        
+        try:
+            api_key = await self.kms.decrypt_api_key(
+                encrypted_key, user_id, provider.lower(), self.mongo_db
+            )
+            
+            if not api_key or not api_key.strip():
+                logger.warning(
+                    f"Decrypted API key is empty for user {user_id}, provider {provider}"
+                )
+                return ""
+            
+            return api_key
+            
+        except Exception as e:
+            logger.warning(
+                f"Failed to decrypt API key cookie for user {user_id}, "
+                f"provider {provider}: {e}"
+            )
+            return ""
+
+    async def get_or_create_session(
+        self,
+        session_id: Optional[str],
+        user_id: str,
+    ) -> tuple[str, bool]:
+        """
+        Get existing session or create a new one.
+        
+        Returns:
+            Tuple of (session_id, created_new_session)
+        """
+        if session_id:
+            return session_id, False
+        
+        new_session_id = await create_chat_session(user_id, mongo_db=self.mongo_db)
+        return new_session_id, True
+
+    async def get_chat_history(
+        self,
+        session_id: str,
+        limit: int = 10,
+    ) -> List[Dict[str, str]]:
+        """
+        Retrieve chat history for a session.
+        
+        Returns:
+            List of message dicts with 'role' and 'content' keys
+        """
+        raw_history = await get_last_messages(
+            session_id=session_id,
+            limit=limit + 1,  # Get one extra to exclude current message
+            mongo_db=self.mongo_db,
+        )
+        
+        # Exclude the last message (current query)
+        raw_history = raw_history[:-1] if raw_history else []
+        
+        return [
+            {"role": m.get("role"), "content": m.get("content", "")}
+            for m in raw_history
+        ]
+
+    async def perform_search(
+        self,
+        query: str,
+        top_k: int = 5,
+    ) -> Dict[str, Any]:
+        """
+        Perform semantic search without generation.
+        
+        Returns:
+            Dict with query, mode, and results
+        """
+        retriever = EmbeddingRetriever(
+            model=self.embedding_model,
+            qdrant=self.qdrant_client,
+            collection_name=self.collection_name,
+        )
+        
+        results = await retriever.retrieve(query, top_k=top_k)
+        
+        return {
+            "query": query,
+            "mode": "search",
+            "results": results,
+        }
+
+    async def generate_response(
+        self,
+        query: str,
+        session_id: str,
+        user_id: str,
+        provider: Literal["openai", "gemini"],
+        model: Optional[str] = None,
+        api_key: Optional[str] = None,
+        top_k: int = 5,
+    ) -> Dict[str, Any]:
+        """
+        Generate a response using RAG pipeline.
+        
+        Args:
+            query: User's question
+            session_id: Chat session ID
+            user_id: User ID for logging
+            provider: LLM provider (openai or gemini)
+            model: Optional specific model name
+            api_key: Optional user's API key
+            top_k: Number of chunks to retrieve
+            
+        Returns:
+            Dict with response, session_id, message IDs, and response ID
+        """
+        start_time = time.time()
+        
+        # Create retriever
+        retriever = EmbeddingRetriever(
+            model=self.embedding_model,
+            qdrant=self.qdrant_client,
+            collection_name=self.collection_name,
+        )
+        
+        # Create generator
+        if provider.lower() == "gemini" and not model:
+            generator = RAGGenerator(
+                retriever=retriever,
+                llm_client=self.default_llm_client,
+            )
+        else:
+            provider_enum = LLMProvider(provider.lower())
+            generator = RAGGenerator(
+                retriever=retriever,
+                provider=provider_enum,
+                model_name=model,
+            )
+        
+        # Save user message
+        user_message_id = await insert_chat_message(
+            {
+                "sessionId": session_id,
+                "role": "user",
+                "content": query,
+            },
+            mongo_db=self.mongo_db,
+        )
+        
+        # Get chat history
+        history = await self.get_chat_history(session_id, limit=10)
+        
+        # Generate response
+        result = await generator.generate_response(
+            query,
+            top_k=top_k,
+            api_key=api_key,
+            include_sources=True,
+            history=history,
+        )
+        
+        # Generate response ID
+        response_id = f"resp_{ObjectId()}"
+        
+        # Save assistant message
+        message_id = await insert_chat_message(
+            {
+                "sessionId": session_id,
+                "role": "assistant",
+                "content": result.get("response", ""),
+                "responseId": response_id,
+            },
+            mongo_db=self.mongo_db,
+        )
+        
+        # Log RAG interaction
+        await self._log_interaction(
+            query=query,
+            response=result.get("response", ""),
+            sources=result.get("sources", []),
+            session_id=session_id,
+            provider=provider,
+            model=model,
+            response_id=response_id,
+            execution_time=time.time() - start_time,
+        )
+        
+        # Prepare response
+        result.pop("sources", None)
+        result["session_id"] = session_id
+        result["userMessageId"] = user_message_id
+        result["messageId"] = message_id
+        result["responseId"] = response_id
+        
+        return result
+
+    async def _log_interaction(
+        self,
+        query: str,
+        response: str,
+        sources: List[Dict[str, Any]],
+        session_id: str,
+        provider: str,
+        model: Optional[str],
+        response_id: str,
+        execution_time: float,
+    ) -> None:
+        """Log RAG interaction for analytics."""
+        try:
+            contexts = [str(s.get("text", "")) for s in (sources or [])]
+            
+            await log_rag_interaction(
+                {
+                    "question": query,
+                    "answer": response,
+                    "contexts": contexts,
+                    "metadata": {
+                        "session_id": session_id,
+                        "provider": provider,
+                        "model": model if model else "system",
+                        "response_id": response_id,
+                        "execution_time_seconds": execution_time,
+                    },
+                },
+                mongo_db=self.mongo_db,
+            )
+        except Exception:
+            logger.warning("Failed to log RAG interaction", exc_info=True)
+
+    async def process_chat_request(
+        self,
+        query: str,
+        user_id: str,
+        provider: Literal["openai", "gemini"],
+        mode: Literal["search", "generate"] = "generate",
+        model: Optional[str] = None,
+        session_id: Optional[str] = None,
+        encrypted_api_key: Optional[str] = None,
+        top_k: int = 5,
+    ) -> Dict[str, Any]:
+        """
+        Main entry point for processing chat requests.
+        
+        This orchestrates the entire chat flow:
+        1. Decrypt API key if provided
+        2. Get or create session
+        3. Either perform search or generate response
+        
+        Args:
+            query: User's question
+            user_id: User ID
+            provider: LLM provider
+            mode: 'search' or 'generate'
+            model: Optional model name
+            session_id: Optional existing session ID
+            encrypted_api_key: Optional encrypted API key from cookie
+            top_k: Number of chunks to retrieve
+            
+        Returns:
+            Dict with response data
+        """
+        # Decrypt API key if provided
+        api_key = await self.decrypt_api_key(
+            encrypted_api_key, user_id, provider
+        )
+        
+        # Get or create session
+        session_id, _ = await self.get_or_create_session(session_id, user_id)
+        
+        # Handle search mode
+        if mode == "search":
+            return await self.perform_search(query, top_k)
+        
+        # Handle generate mode
+        return await self.generate_response(
+            query=query,
+            session_id=session_id,
+            user_id=user_id,
+            provider=provider,
+            model=model,
+            api_key=api_key if api_key else None,
+            top_k=top_k,
+        )


### PR DESCRIPTION
## Description
The  assistant was failing to recall conversation history correctly because it was not fetching enough messages from the database. This change increases the chat history limit from 5 to 11 messages, providing the language model with the last five full conversation turns (10 messages) plus the current user query.  Besides that also refactored the chat system separating the business logic.


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [x ] Refactoring / Code cleanup

## Checklist
- [ x] I have read the contributing guidelines
- [ x] I have added or updated tests where applicable
- [x ] I have added or updated documentation where applicable
- [ x] I have reviewed and tested my changes, and I have run the code to confirm it works properly

## How Has This Been Tested?
Manually
