### PR TITLE
Feat/title generation

### DIFF
--- a/Backend/app/db/chat_db.py
+++ b/Backend/app/db/chat_db.py
@@ -90,6 +90,19 @@ async def get_chat_session_by_id(session_id: str, mongo_db: Database = None) -> 
     return await collection.find_one({"sessionId": session_id}, {"_id": 0})
 
 
+async def update_chat_session_title(
+    session_id: str, title: str, mongo_db: Database = None
+) -> bool:
+    """
+    Update the title of a chat session.
+    """
+    collection = _get_collection(mongo_db, "chat_sessions")
+    result = await collection.update_one(
+        {"sessionId": session_id}, {"$set": {"title": title}}
+    )
+    return result.modified_count > 0
+
+
 async def get_chat_sessions(
     user_id: str,
     page: int = 1,

--- a/Backend/app/model/chat_session.py
+++ b/Backend/app/model/chat_session.py
@@ -7,6 +7,7 @@ class ChatSessionSchema(BaseModel):
     sessionId: str
     createdAt: datetime
     userId: Optional[str] = None
+    title: Optional[str] = None
 
 
 class ChatSessionCreate(BaseModel):

--- a/Backend/app/routers/chat.py
+++ b/Backend/app/routers/chat.py
@@ -1,7 +1,14 @@
 from typing import Optional, Literal
 from datetime import datetime, timedelta, timezone
 from pydantic import BaseModel, Field
-from fastapi import APIRouter, HTTPException, Depends, Request, Response
+from fastapi import (
+    APIRouter,
+    HTTPException,
+    Depends,
+    Request,
+    Response,
+    BackgroundTasks,
+)
 
 from app.dependencies import get_chat_service, get_current_user
 from app.services.chat_service import ChatService
@@ -27,6 +34,7 @@ async def chat(
     request: Request,
     response: Response,
     chat_request: ChatRequest,
+    background_tasks: BackgroundTasks,
     chat_service: ChatService = Depends(get_chat_service),
     current_user: dict = Depends(get_current_user),
 ):
@@ -52,6 +60,7 @@ async def chat(
             query=chat_request.query,
             user_id=current_user["id"],
             provider=provider,
+            background_tasks=background_tasks,
             mode=chat_request.mode,
             model=chat_request.model,
             session_id=chat_request.session_id,

--- a/Backend/app/routers/chat_sessions.py
+++ b/Backend/app/routers/chat_sessions.py
@@ -52,6 +52,9 @@ async def list_sessions(
 @router.get("/{session_id}", response_model=ChatSessionWithMessages)
 async def get_session(
     session_id: str,
+    include_messages: bool = Query(
+        True, description="Whether to include messages in the response"
+    ),
     current_user: dict = Depends(get_current_user),
     mongo_db: Database = Depends(get_mongo_db),
 ):
@@ -67,9 +70,13 @@ async def get_session(
 
     if session.get("userId") != current_user["id"]:
         raise HTTPException(status_code=403, detail="Access denied")
-        
-    messages = await get_messages_for_session(session_id, mongo_db=mongo_db)
-    session["messages"] = messages
+
+    if include_messages:
+        messages = await get_messages_for_session(session_id, mongo_db=mongo_db)
+        session["messages"] = messages
+    else:
+        session["messages"] = []
+
     return session
 
 

--- a/Frontend/src/pages/Chat.tsx
+++ b/Frontend/src/pages/Chat.tsx
@@ -94,6 +94,20 @@ function Chat() {
     return null;
   }
 
+  const [restoredSessionId, setRestoredSessionId] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (
+      selectedSessionId && 
+      messages.length === 0 && 
+      !isLoadingMessages &&
+      restoredSessionId !== selectedSessionId
+    ) {
+      setRestoredSessionId(selectedSessionId);
+      useChatStore.getState().selectSession(selectedSessionId);
+    }
+  }, [selectedSessionId, messages.length, isLoadingMessages, restoredSessionId]);
+
   return (
     <div className="flex h-screen bg-white dark:bg-black overflow-hidden">
       {/* Left panel: sidebar */}

--- a/Frontend/src/services/chatService.ts
+++ b/Frontend/src/services/chatService.ts
@@ -48,6 +48,19 @@ export const getSessionMessages = async (sessionId: string): Promise<Message[]> 
   }
 };
 
+// Get a single session
+export const getSession = async (sessionId: string, includeMessages: boolean = true): Promise<ChatSessionWithMessages> => {
+  try {
+    const response = await axiosInstance.get<ChatSessionWithMessages>(`${SESSIONS_BASE_URL}/${sessionId}`, {
+      params: { include_messages: includeMessages },
+    });
+    return response.data;
+  } catch (error) {
+    handleAxiosError(error, 'Sessions');
+    throw error;
+  }
+};
+
 // Cursor-based message retrieval
 export const getSessionMessagesCursor = async (
   sessionId: string,


### PR DESCRIPTION
# Pull Request

## Description
This PR implements automated, AI-driven title generation for chat sessions to improve history organization reliability. The backend now triggers a background task via FastAPI's BackgroundTasks upon the first message of a session to generate a concise title using the LLM, storing it in the database. On the frontend, the chat interface seamlessly updates the title using a new optimized, lightweight session polling mechanism that fetches metadata without reloading the full message history or session list.

Additionally, this PR fixes a session persistence issue where refreshing the page would reset the active chat view. A new logic in the Chat component detects when a session ID is restored from local storage without its messages and automatically triggers a fetch to re-hydrate the chat history, ensuring the user stays in their active context across page reloads.

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Code cleanup

## Checklist
- [x] I have read the contributing guidelines
- [ ] I have added or updated tests where applicable
- [ ] I have added or updated documentation where applicable
- [x] I have reviewed and tested my changes, and I have run the code to confirm it works properly

## How Has This Been Tested?
With the already existing test suite and manual verification


