### PR TITLE
Fix/kms chat cleanup

### DIFF
--- a/Backend/app/db/chat_db.py
+++ b/Backend/app/db/chat_db.py
@@ -1,4 +1,4 @@
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Dict
 from bson import ObjectId
 from pymongo.database import Database
 from pymongo.errors import PyMongoError
@@ -72,13 +72,31 @@ async def create_chat_session(user_id: str, mongo_db: Database = None) -> str:
     return sid
 
 
-async def delete_chat_session(session_id: str, mongo_db: Database = None) -> int:
+async def delete_chat_session(session_id: str, mongo_db: Database = None) -> Dict[str, int]:
     """
-    Delete a chat session document. Returns number of documents deleted (0 or 1).
+    Delete a chat session and all session-scoped records.
+
+    Child records are removed before the session document so we do not leave
+    orphaned conversation data behind if a later delete fails.
     """
-    collection = _get_collection(mongo_db, "chat_sessions")
-    result = await collection.delete_one({"sessionId": session_id})
-    return result.deleted_count
+    sessions_collection = _get_collection(mongo_db, "chat_sessions")
+    messages_collection = _get_collection(mongo_db, "chat_messages")
+    feedback_collection = _get_collection(mongo_db, "feedback")
+    rag_logs_collection = _get_collection(mongo_db, "rag_logs")
+
+    messages_result = await messages_collection.delete_many({"sessionId": session_id})
+    feedback_result = await feedback_collection.delete_many({"sessionId": session_id})
+    rag_logs_result = await rag_logs_collection.delete_many(
+        {"metadata.session_id": session_id}
+    )
+    session_result = await sessions_collection.delete_one({"sessionId": session_id})
+
+    return {
+        "sessions": session_result.deleted_count,
+        "messages": messages_result.deleted_count,
+        "feedback": feedback_result.deleted_count,
+        "rag_logs": rag_logs_result.deleted_count,
+    }
 
 
 async def get_chat_session_by_id(session_id: str, mongo_db: Database = None) -> dict | None:

--- a/Backend/app/routers/chat_sessions.py
+++ b/Backend/app/routers/chat_sessions.py
@@ -141,12 +141,19 @@ async def delete_session(
         raise HTTPException(status_code=403, detail="Access denied")
 
     try:
-        deleted_count = await delete_chat_session(session_id, mongo_db=mongo_db)
-        if deleted_count == 0:
+        deleted_counts = await delete_chat_session(session_id, mongo_db=mongo_db)
+        if deleted_counts["sessions"] == 0:
             raise HTTPException(
                 status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
                 detail="Failed to delete session",
             )
+        logger.info(
+            "Deleted session %s with %s messages, %s feedback entries, and %s rag logs",
+            session_id,
+            deleted_counts["messages"],
+            deleted_counts["feedback"],
+            deleted_counts["rag_logs"],
+        )
         return None
     except HTTPException:
         raise

--- a/Backend/tests/unit/test_chat_db.py
+++ b/Backend/tests/unit/test_chat_db.py
@@ -162,36 +162,105 @@ class TestDeleteChatSession:
     
     @pytest.mark.asyncio
     async def test_delete_chat_session_success(self):
-        """Test successfully deleting a chat session."""
+        """Test successfully deleting a chat session and related records."""
         session_id = str(ObjectId())
-        
-        mock_collection = AsyncMock()
-        mock_result = MagicMock()
-        mock_result.deleted_count = 1
-        mock_collection.delete_one = AsyncMock(return_value=mock_result)
+
+        mock_sessions = AsyncMock()
+        mock_messages = AsyncMock()
+        mock_feedback = AsyncMock()
+        mock_rag_logs = AsyncMock()
+
+        mock_session_result = MagicMock()
+        mock_session_result.deleted_count = 1
+        mock_sessions.delete_one = AsyncMock(return_value=mock_session_result)
+
+        mock_messages_result = MagicMock()
+        mock_messages_result.deleted_count = 4
+        mock_messages.delete_many = AsyncMock(return_value=mock_messages_result)
+
+        mock_feedback_result = MagicMock()
+        mock_feedback_result.deleted_count = 2
+        mock_feedback.delete_many = AsyncMock(return_value=mock_feedback_result)
+
+        mock_rag_logs_result = MagicMock()
+        mock_rag_logs_result.deleted_count = 3
+        mock_rag_logs.delete_many = AsyncMock(return_value=mock_rag_logs_result)
+
         mock_mongo_db = MagicMock()
-        
-        with patch("app.db.chat_db._get_collection", return_value=mock_collection):
+
+        collections = {
+            "chat_sessions": mock_sessions,
+            "chat_messages": mock_messages,
+            "feedback": mock_feedback,
+            "rag_logs": mock_rag_logs,
+        }
+
+        def get_collection_side_effect(_mongo_db, name):
+            return collections[name]
+
+        with patch("app.db.chat_db._get_collection", side_effect=get_collection_side_effect):
             result = await delete_chat_session(session_id, mock_mongo_db)
-            
-            assert result == 1
-            mock_collection.delete_one.assert_called_once_with({"sessionId": session_id})
+
+            assert result == {
+                "sessions": 1,
+                "messages": 4,
+                "feedback": 2,
+                "rag_logs": 3,
+            }
+            mock_messages.delete_many.assert_called_once_with({"sessionId": session_id})
+            mock_feedback.delete_many.assert_called_once_with({"sessionId": session_id})
+            mock_rag_logs.delete_many.assert_called_once_with(
+                {"metadata.session_id": session_id}
+            )
+            mock_sessions.delete_one.assert_called_once_with({"sessionId": session_id})
     
     @pytest.mark.asyncio
     async def test_delete_chat_session_not_found(self):
-        """Test deleting non-existent session."""
+        """Test deleting a session when only related records remain."""
         session_id = str(ObjectId())
-        
-        mock_collection = AsyncMock()
-        mock_result = MagicMock()
-        mock_result.deleted_count = 0
-        mock_collection.delete_one = AsyncMock(return_value=mock_result)
+
+        mock_sessions = AsyncMock()
+        mock_messages = AsyncMock()
+        mock_feedback = AsyncMock()
+        mock_rag_logs = AsyncMock()
+
+        mock_session_result = MagicMock()
+        mock_session_result.deleted_count = 0
+        mock_sessions.delete_one = AsyncMock(return_value=mock_session_result)
+
+        mock_messages_result = MagicMock()
+        mock_messages_result.deleted_count = 1
+        mock_messages.delete_many = AsyncMock(return_value=mock_messages_result)
+
+        mock_feedback_result = MagicMock()
+        mock_feedback_result.deleted_count = 1
+        mock_feedback.delete_many = AsyncMock(return_value=mock_feedback_result)
+
+        mock_rag_logs_result = MagicMock()
+        mock_rag_logs_result.deleted_count = 1
+        mock_rag_logs.delete_many = AsyncMock(return_value=mock_rag_logs_result)
+
         mock_mongo_db = MagicMock()
-        
-        with patch("app.db.chat_db._get_collection", return_value=mock_collection):
+
+        collections = {
+            "chat_sessions": mock_sessions,
+            "chat_messages": mock_messages,
+            "feedback": mock_feedback,
+            "rag_logs": mock_rag_logs,
+        }
+
+        def get_collection_side_effect(_mongo_db, name):
+            return collections[name]
+
+        with patch("app.db.chat_db._get_collection", side_effect=get_collection_side_effect):
             result = await delete_chat_session(session_id, mock_mongo_db)
-            
-            assert result == 0
+
+            assert result == {
+                "sessions": 0,
+                "messages": 1,
+                "feedback": 1,
+                "rag_logs": 1,
+            }
 
 
 class TestGetChatSessionById:

--- a/Frontend/src/components/modals/MobileSettingsModal.tsx
+++ b/Frontend/src/components/modals/MobileSettingsModal.tsx
@@ -6,6 +6,7 @@ import { X, User, Palette, Globe, ArrowLeft, ChevronRight, Plus } from 'lucide-r
 import ModelList from '../ui/ModelList'
 import ModelForm from '../ui/ModelForm'
 import { Button } from '../ui/button'
+import { useKMS } from '../../hooks/useKMS'
 import { 
   createModelFromForm, 
   updateModelFromForm, 
@@ -26,6 +27,7 @@ function MobileSettingsModal({ isOpen, onClose }: MobileSettingsModalProps) {
   const { models, addModel, updateModel, removeModel } = useModelStore()
   const { email, username, userId, isAuthenticated, accountCreatedAt } = useUserStore()
   const { theme, setTheme } = useTheme()
+  const { deleteAPIKey } = useKMS()
   const [activeTab, setActiveTab] = useState<SettingsTab>(null)
   const [showAddModal, setShowAddModal] = useState(false)
   const [editingModel, setEditingModel] = useState<string | null>(null)
@@ -70,6 +72,27 @@ function MobileSettingsModal({ isOpen, onClose }: MobileSettingsModalProps) {
 
   function handleDelete(modelId: string) {
     setConfirmDeleteId(modelId)
+  }
+
+  async function performDelete() {
+    if (!confirmDeleteId) return
+
+    const model = models.find((m) => m.id === confirmDeleteId)
+    if (!model) {
+      setConfirmDeleteId(null)
+      return
+    }
+
+    if (model.provider) {
+      try {
+        await deleteAPIKey(model.provider)
+      } catch (err) {
+        console.error('Failed to delete key via KMS', err)
+      }
+    }
+
+    removeModel(model.id)
+    setConfirmDeleteId(null)
   }
 
   function closeModal() {
@@ -328,10 +351,7 @@ function MobileSettingsModal({ isOpen, onClose }: MobileSettingsModalProps) {
                 <Button variant="outline" onClick={() => setConfirmDeleteId(null)}>Cancel</Button>
                 <Button 
                   className="bg-red-600 hover:bg-red-700 text-white"
-                  onClick={() => {
-                    removeModel(confirmDeleteId)
-                    setConfirmDeleteId(null)
-                  }}
+                  onClick={performDelete}
                 >
                   Delete
                 </Button>


### PR DESCRIPTION
# Pull Request

## Description
This PR fixes two production data-consistency issues:

- Mobile settings now deletes custom provider keys through the backend KMS flow, matching desktop behavior.
- Deleting a chat session now cascades to its chat messages, feedback, and RAG logs so conversations are fully removed instead of leaving orphaned records behind.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Documentation update
- [ ] Refactoring / Code cleanup

## Checklist
- [x] I have read the contributing guidelines
- [x] I have added or updated tests where applicable
- [ ] I have added or updated documentation where applicable
- [x] I have reviewed and tested my changes, and I have run the code to confirm it works properly

## How Has This Been Tested?
Please describe the tests you ran to verify your changes.
- `npm run lint`
- `npm run build`
- using the backend test suite

