### PR TITLE
add settings UI for model keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,232 @@
+# Dependencies
+node_modules/
+.venv/
+venv/
+env/
+ENV/
+
+# Logs
+*.log
+logs/
+Backend/logs/
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# Coverage directory used by tools like istanbul
+coverage/
+*.lcov
+
+# nyc test coverage
+.nyc_output
+
+# Grunt intermediate storage (https://gruntjs.com/creating-plugins#storing-task-files)
+.grunt
+
+# Bower dependency directory (https://bower.io/)
+bower_components
+
+# node-waf configuration
+.lock-wscript
+
+# Compiled binary addons (https://nodejs.org/api/addons.html)
+build/Release
+
+# Dependency directories
+jspm_packages/
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Microbundle cache
+.rpt2_cache/
+.rts2_cache_cjs/
+.rts2_cache_es/
+.rts2_cache_umd/
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variables file
+.env
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local
+
+# parcel-bundler cache (https://parceljs.org/)
+.cache
+.parcel-cache
+
+# Next.js build output
+.next
+
+# Nuxt.js build / generate output
+.nuxt
+dist
+
+# Gatsby files
+.cache/
+public
+
+# Vuepress build output
+.vuepress/dist
+
+# Serverless directories
+.serverless/
+
+# FuseBox cache
+.fusebox/
+
+# DynamoDB Local files
+.dynamodb/
+
+# TernJS port file
+.tern-port
+
+# Stores VSCode versions used for testing VSCode extensions
+.vscode-test
+
+# Python
+__pycache__/
+*.py[cod]
+*$py.class
+*.so
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# pyenv
+.python-version
+
+# celery beat schedule file
+celerybeat-schedule
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# IDE
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db
+
+# Database
+*.db
+*.sqlite
+*.sqlite3
+
+# Temporary files
+*.tmp
+*.temp

--- a/Frontend/src/App.tsx
+++ b/Frontend/src/App.tsx
@@ -3,6 +3,7 @@ import { useEffect } from "react"
 import Auth from "./pages/Auth"
 import Chat from "./pages/Chat"
 import Admin from "./pages/Admin"
+import Settings from "./pages/Settings"
 import NotFoundPage from "./pages/NotFound"
 import { isAuthenticated } from "./lib/auth"
 
@@ -19,6 +20,7 @@ function App() {
         <Route path="/" element={<Navigate to={authed ? "/chat" : "/login"} replace />} />
         <Route path="/login" element={<Auth />} />
         <Route path="/chat" element={<Chat />} />
+        <Route path="/settings" element={<Settings />} />
         <Route path="/admin/*" element={<Admin />} />
         <Route path="*" element={<NotFoundPage />} />
       </Routes>

--- a/Frontend/src/components/chat/ChatHeader.tsx
+++ b/Frontend/src/components/chat/ChatHeader.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
-import ModelSelector from '../ui/ModelSelector'
 import { User, Settings, LogOut, Menu } from 'lucide-react'
 import { useUserStore } from '../../store/useUserStore'
 
@@ -48,7 +47,6 @@ function ChatHeader({ onToggleSidebar, onOpenSettings }: ChatHeaderProps) {
             <Menu className="w-4 h-4" />
           </button>
         )}
-        <ModelSelector />
       </div>
       <div className="flex items-center gap-2.5 relative" ref={profileRef}>
         <button 

--- a/Frontend/src/components/chat/MessageInput.tsx
+++ b/Frontend/src/components/chat/MessageInput.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
-import { ArrowUp } from 'lucide-react'
+import { ArrowUp, Settings } from 'lucide-react'
+import ModelSelector from '../ui/ModelSelector'
 
 interface ChatInputProps {
   onSend: (text: string) => void
@@ -32,16 +33,21 @@ function MessageInput({ onSend, isSendingMessage = false }: ChatInputProps) {
                 submit(e as any);
               }
             }}
-            className="w-full resize-none bg-transparent pl-4 pr-12 py-3 min-h-[52px] max-h-[200px] focus:outline-none text-sm text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-500 dark:placeholder:text-zinc-400 scrollbar-thin"
+            className="w-full resize-none bg-transparent pl-4 pr-20 py-3 min-h-[52px] max-h-[200px] focus:outline-none text-sm text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-500 dark:placeholder:text-zinc-400 scrollbar-thin"
           />
-          <button
-            type="submit"
-            disabled={!text.trim() || isSendingMessage}
-            className="absolute right-3 top-1/2 -translate-y-1/2 p-2 rounded-lg bg-zinc-900 dark:bg-white text-white dark:text-black hover:bg-zinc-700 dark:hover:bg-zinc-200 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
-            title={isSendingMessage ? "Sending..." : "Send message"}
-          >
-            <ArrowUp className="w-4 h-4" />
-          </button>
+          <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
+            <button
+              type="submit"
+              disabled={!text.trim() || isSendingMessage}
+              className="p-2 rounded-lg bg-zinc-900 dark:bg-white text-white dark:text-black hover:bg-zinc-700 dark:hover:bg-zinc-200 transition-colors disabled:opacity-30 disabled:cursor-not-allowed"
+              title={isSendingMessage ? "Sending..." : "Send message"}
+            >
+              <ArrowUp className="w-4 h-4" />
+            </button>
+          </div>
+        </div>
+        <div className="absolute right-16 top-1/2 -translate-y-1/2">
+          <ModelSelector />
         </div>
       </div>
     </form>

--- a/Frontend/src/components/chat/MessageInput.tsx
+++ b/Frontend/src/components/chat/MessageInput.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { ArrowUp, Settings } from 'lucide-react'
+import { ArrowUp } from 'lucide-react'
 import ModelSelector from '../ui/ModelSelector'
 
 interface ChatInputProps {
@@ -21,7 +21,10 @@ function MessageInput({ onSend, isSendingMessage = false }: ChatInputProps) {
   return (
     <form onSubmit={submit} className="w-full max-w-2xl mx-auto px-4 mb-4">
       <div className="relative">
-        <div className="w-full bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-2xl shadow-sm overflow-hidden">
+        <div className="w-full bg-white dark:bg-zinc-800 border border-gray-200 dark:border-zinc-700 rounded-2xl shadow-sm overflow-visible">
+          <div className="absolute left-5 top-1/2 -translate-y-1/2">
+            <ModelSelector />
+          </div>
           <textarea
             value={text}
             onChange={e => setText(e.target.value)}
@@ -33,7 +36,7 @@ function MessageInput({ onSend, isSendingMessage = false }: ChatInputProps) {
                 submit(e as any);
               }
             }}
-            className="w-full resize-none bg-transparent pl-4 pr-20 py-3 min-h-[52px] max-h-[200px] focus:outline-none text-sm text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-500 dark:placeholder:text-zinc-400 scrollbar-thin"
+            className="w-full resize-none bg-transparent pl-16 pr-20 py-3 min-h-[52px] max-h-[200px] focus:outline-none text-sm text-zinc-900 dark:text-zinc-100 placeholder:text-zinc-500 dark:placeholder:text-zinc-400 scrollbar-thin"
           />
           <div className="absolute right-3 top-1/2 -translate-y-1/2 flex items-center gap-2">
             <button
@@ -45,9 +48,6 @@ function MessageInput({ onSend, isSendingMessage = false }: ChatInputProps) {
               <ArrowUp className="w-4 h-4" />
             </button>
           </div>
-        </div>
-        <div className="absolute right-16 top-1/2 -translate-y-1/2">
-          <ModelSelector />
         </div>
       </div>
     </form>

--- a/Frontend/src/components/modals/MobileSettingsModal.tsx
+++ b/Frontend/src/components/modals/MobileSettingsModal.tsx
@@ -29,7 +29,7 @@ function MobileSettingsModal({ isOpen, onClose }: MobileSettingsModalProps) {
   const [activeTab, setActiveTab] = useState<SettingsTab>(null)
   const [showAddModal, setShowAddModal] = useState(false)
   const [editingModel, setEditingModel] = useState<string | null>(null)
-  const [formData, setFormData] = useState<ModelFormData>({ provider: '', apiKey: '' })
+  const [formData, setFormData] = useState<ModelFormData>({ provider: '', modelName: '', apiKey: '' })
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
 
   if (!isOpen) return null
@@ -75,7 +75,7 @@ function MobileSettingsModal({ isOpen, onClose }: MobileSettingsModalProps) {
   function closeModal() {
     setShowAddModal(false)
     setEditingModel(null)
-    setFormData({ provider: '', apiKey: '' })
+    setFormData({ provider: '', modelName: '', apiKey: '' })
   }
 
   function goBack() {

--- a/Frontend/src/components/modals/SettingsModal.tsx
+++ b/Frontend/src/components/modals/SettingsModal.tsx
@@ -29,7 +29,7 @@ function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
   const [activeTab, setActiveTab] = useState<SettingsTab>('general')
   const [isMobile, setIsMobile] = useState(false)
   const [showAddModal, setShowAddModal] = useState(false)
-  const [formData, setFormData] = useState<ModelFormData>({ provider: '', apiKey: '' })
+  const [formData, setFormData] = useState<ModelFormData>({ provider: '', modelName: '', apiKey: '' })
   const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
   const { deleteAPIKey } = useKMS()
 
@@ -96,7 +96,7 @@ function SettingsModal({ isOpen, onClose }: SettingsModalProps) {
 
   function closeModal() {
     setShowAddModal(false)
-    setFormData({ provider: '', apiKey: '' })
+    setFormData({ provider: '', modelName: '', apiKey: '' })
   }
 
   return (

--- a/Frontend/src/components/ui/ModelForm.tsx
+++ b/Frontend/src/components/ui/ModelForm.tsx
@@ -1,4 +1,4 @@
-import { ModelFormData } from '../../lib/models'
+import { ModelFormData, getModelOptionsForProvider, getModelOption } from '../../lib/models'
 import { Button } from './button'
 import { Input } from './input'
 import { Label } from './label'
@@ -22,6 +22,12 @@ function ModelForm({ formData, onFormChange, onSubmit, onCancel, isEditing }: Mo
   const [providerMismatch, setProviderMismatch] = useState<ProviderMismatchInfo | null>(null)
   const [detectedProvider, setDetectedProvider] = useState<string | null>(null)
   const successTimer = useRef<number | null>(null)
+  const availableModels = getModelOptionsForProvider(formData.provider)
+  const selectedModel = getModelOption(formData.provider, formData.modelName)
+
+  const handleProviderChange = (value: string) => {
+    onFormChange({ ...formData, provider: value, modelName: '' })
+  }
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -87,19 +93,7 @@ function ModelForm({ formData, onFormChange, onSubmit, onCancel, isEditing }: Mo
         <Label htmlFor="provider">Provider</Label>
         <ProviderSelect
           value={formData.provider}
-          onChange={value => onFormChange({ ...formData, provider: value })}
-          className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-black focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-600"
-          required
-        />
-      </div>
-      <div className="space-y-2">
-        <Label htmlFor="model-name">Model Name</Label>
-        <Input
-          id="model-name"
-          type="text"
-          placeholder="e.g. gemini-2.0-flash, gpt-4-turbo, claude-3-sonnet"
-          value={formData.modelName}
-          onChange={e => onFormChange({ ...formData, modelName: e.target.value })}
+          onChange={handleProviderChange}
           className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-black focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-600"
           required
         />
@@ -112,8 +106,38 @@ function ModelForm({ formData, onFormChange, onSubmit, onCancel, isEditing }: Mo
           placeholder="Enter your API key"
           value={formData.apiKey}
           onChange={e => onFormChange({ ...formData, apiKey: e.target.value })}
+          autoComplete="off"
           required
         />
+      </div>
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="model-name">Model Preference</Label>
+          <span className="text-[10px] uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Supported list only</span>
+        </div>
+        <select
+          id="model-name"
+          value={formData.modelName}
+          onChange={e => onFormChange({ ...formData, modelName: e.target.value })}
+          className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-black focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-600 disabled:bg-zinc-100 disabled:dark:bg-zinc-900/40"
+          required
+          disabled={!formData.provider || availableModels.length === 0}
+        >
+          <option value="">
+            {formData.provider ? 'Select a supported model' : 'Pick a provider first'}
+          </option>
+          {availableModels.map(option => (
+            <option key={option.value} value={option.value}>
+              {option.label}
+            </option>
+          ))}
+        </select>
+        {formData.provider && availableModels.length === 0 && (
+          <p className="text-xs text-red-600 dark:text-red-400">We do not support custom models for this provider yet.</p>
+        )}
+        {selectedModel?.description && (
+          <p className="text-xs text-zinc-500 dark:text-zinc-400">{selectedModel.description}</p>
+        )}
       </div>
       
       {error && (
@@ -136,7 +160,7 @@ function ModelForm({ formData, onFormChange, onSubmit, onCancel, isEditing }: Mo
             <button
               type="button"
               className="text-xs font-semibold text-blue-600 dark:text-blue-400 underline"
-              onClick={() => onFormChange({ ...formData, provider: detectedProvider! })}
+              onClick={() => handleProviderChange(detectedProvider!)}
             >
               Switch to {detectedProvider}
             </button>

--- a/Frontend/src/components/ui/ModelForm.tsx
+++ b/Frontend/src/components/ui/ModelForm.tsx
@@ -25,7 +25,7 @@ function ModelForm({ formData, onFormChange, onSubmit, onCancel, isEditing }: Mo
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault()
-    if (!formData.provider || !formData.apiKey) return
+    if (!formData.provider || !formData.modelName || !formData.apiKey) return
     
     setIsSubmitting(true)
     setError(null)
@@ -88,6 +88,18 @@ function ModelForm({ formData, onFormChange, onSubmit, onCancel, isEditing }: Mo
         <ProviderSelect
           value={formData.provider}
           onChange={value => onFormChange({ ...formData, provider: value })}
+          className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-black focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-600"
+          required
+        />
+      </div>
+      <div className="space-y-2">
+        <Label htmlFor="model-name">Model Name</Label>
+        <Input
+          id="model-name"
+          type="text"
+          placeholder="e.g. gemini-2.0-flash, gpt-4-turbo, claude-3-sonnet"
+          value={formData.modelName}
+          onChange={e => onFormChange({ ...formData, modelName: e.target.value })}
           className="w-full px-3 py-2 text-sm rounded-lg border border-zinc-200 dark:border-zinc-800 bg-white dark:bg-black focus:outline-none focus:ring-2 focus:ring-zinc-400 dark:focus:ring-zinc-600"
           required
         />

--- a/Frontend/src/components/ui/ModelSelector.tsx
+++ b/Frontend/src/components/ui/ModelSelector.tsx
@@ -1,98 +1,155 @@
-import { useState, useEffect, useRef } from 'react'
+import { useState, useEffect, useRef, useLayoutEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { useModelStore } from '../../store/useModelStore'
 import { Bot } from 'lucide-react'
+
+import { useModelStore } from '../../store/useModelStore'
 import { useKMS } from '../../hooks/useKMS'
 
-function ModelSelector() {
-  const navigate = useNavigate()
-  const { deleteAPIKey } = useKMS()
-  const { models, activeId, setActive, clearCustomModels } = useModelStore()
-  const activeModel = models.find(m => m.id === activeId)
+const PROVIDERS_TO_DELETE = ['gemini', 'openai'] as const
+
+const ModelSelector = () => {
   const [open, setOpen] = useState(false)
   const dropdownRef = useRef<HTMLDivElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const navigate = useNavigate()
+  const [menuPosition, setMenuPosition] = useState({ alignRight: false, dropUp: false })
+
+  const { deleteAPIKey } = useKMS()
+  const { models, activeId, setActive, clearCustomModels } = useModelStore()
+
+  const activeModel = models.find((model) => model.id === activeId)
+  const hasCustomModels = models.some((model) => model.isCustom)
 
   useEffect(() => {
-    function handleClickOutside(event: MouseEvent) {
-      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+    if (!open) {
+      return
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (!dropdownRef.current) {
+        return
+      }
+
+      if (!dropdownRef.current.contains(event.target as Node)) {
         setOpen(false)
       }
     }
 
-    if (open) {
-      document.addEventListener('mousedown', handleClickOutside)
-      return () => document.removeEventListener('mousedown', handleClickOutside)
+    document.addEventListener('mousedown', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
     }
   }, [open])
 
+  useLayoutEffect(() => {
+    if (!open) {
+      return
+    }
+
+    const margin = 12
+
+    const updatePosition = () => {
+      if (!dropdownRef.current || !menuRef.current) {
+        return
+      }
+
+      const triggerRect = dropdownRef.current.getBoundingClientRect()
+      const menuRect = menuRef.current.getBoundingClientRect()
+
+      const alignRight = triggerRect.left + menuRect.width > window.innerWidth - margin
+      const dropUp = triggerRect.bottom + menuRect.height > window.innerHeight - margin
+
+      setMenuPosition({
+        alignRight,
+        dropUp,
+      })
+    }
+
+    updatePosition()
+
+    window.addEventListener('resize', updatePosition)
+    window.addEventListener('scroll', updatePosition, true)
+
+    return () => {
+      window.removeEventListener('resize', updatePosition)
+      window.removeEventListener('scroll', updatePosition, true)
+    }
+  }, [open])
+
+  const handleSelectModel = async (modelId: string, isCustom?: boolean) => {
+    if (!isCustom) {
+      for (const provider of PROVIDERS_TO_DELETE) {
+        try {
+          await deleteAPIKey(provider)
+        } catch (err) {
+          console.debug(`No ${provider} key to delete`)
+        }
+      }
+      clearCustomModels()
+    }
+
+    setActive(modelId)
+    setOpen(false)
+  }
+
   return (
-    <>
-      <div className="relative" ref={dropdownRef}>
-        <button 
-          onClick={() => setOpen(!open)} 
-          className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
-          title="Select Model"
-        >
-          <Bot className="w-4 h-4 text-gray-600 dark:text-gray-400" />
-        </button>
-        
-        {open && (
-          <>
-            <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
-            <div className="absolute left-1/2 bottom-full mb-2 w-56 -translate-x-1/2 rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-black shadow-xl overflow-hidden z-50">
-            <div className="absolute -top-1 left-1/2 -translate-x-1/2 w-2 h-2 bg-white dark:bg-black border-l border-t border-gray-200 dark:border-gray-800 rotate-45"></div>
-            <div className="px-3 py-2 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900">
-              <div className="text-xs font-medium text-gray-600 dark:text-gray-400">Current Model</div>
-              <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{activeModel?.name || 'Select Model'}</div>
+    <div className="relative z-50" ref={dropdownRef}>
+      <button
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex items-center justify-center w-10 h-10 rounded-full bg-white dark:bg-zinc-900 text-gray-700 dark:text-gray-200 shadow-sm border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-500 transition-colors"
+        title={activeModel?.name ? `Current: ${activeModel.name}` : 'Select model'}
+      >
+        <Bot className="w-4 h-4" />
+      </button>
+
+      {open && (
+        <>
+          <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+          <div
+            ref={menuRef}
+            className={`absolute ${menuPosition.alignRight ? 'right-0' : 'left-0'} ${
+              menuPosition.dropUp ? 'bottom-full mb-2' : 'top-full mt-2'
+            } min-w-[15rem] rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-zinc-950 shadow-2xl overflow-hidden`}
+          >
+            <div className="px-4 py-3 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-zinc-900/60">
+              <p className="text-xs font-semibold text-gray-600 dark:text-gray-400 uppercase tracking-wide">Choose a model</p>
+              <p className="text-sm text-gray-500 dark:text-gray-400">Switch between built-in and custom keys</p>
             </div>
-            <div className="max-h-64 overflow-y-auto scrollbar-thin">
-              {models.map(m => (
-                <button 
-                  key={m.id}
-                  onClick={async () => { 
-                    if (!m.isCustom) {
-                      // When switching to default, delete all custom models
-                      const customModels = models.filter(model => model.isCustom)
-                      
-                      // Delete API keys from backend
-                      const providersToDelete = ['gemini', 'openai']
-                      for (const provider of providersToDelete) {
-                        try {
-                          await deleteAPIKey(provider)
-                        } catch (err) {
-                          console.debug(`No ${provider} key to delete`)
-                        }
-                      }
-                      
-                      // Remove all custom models from UI in one go
-                      console.log('[ModelSelector] Clearing all custom models')
-                      clearCustomModels()
-                    }
-                    setActive(m.id); 
-                    setOpen(false) 
-                  }} 
-                  className={`w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-900 transition-colors ${
-                    m.id === activeId ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300' : ''
+            <div className="max-h-72 overflow-y-auto scrollbar-thin">
+              {models.map((model) => (
+                <button
+                  key={model.id}
+                  onClick={() => handleSelectModel(model.id, model.isCustom)}
+                  className={`w-full text-left px-4 py-2.5 text-sm flex flex-col gap-0.5 hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors ${
+                    model.id === activeId ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-200' : ''
                   }`}
                 >
-                  {m.name}
+                  <span className="font-medium">{model.name}</span>
+                  <span className="text-xs text-gray-500 dark:text-gray-400">{model.provider ? model.provider : model.isCustom ? 'Custom' : 'Built-in'}</span>
                 </button>
               ))}
             </div>
-            <button 
-              onClick={() => { 
+            {!hasCustomModels && (
+              <div className="px-4 py-2 text-xs text-gray-600 dark:text-gray-400 border-t border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-zinc-900/60">
+                Add your key to unlock Gemini 3.1 Pro or Flash.
+              </div>
+            )}
+            <button
+              onClick={() => {
                 setOpen(false)
                 navigate('/settings')
-              }} 
-              className="w-full text-left px-3 py-1.5 text-xs border-t border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors font-medium"
+              }}
+              className={`w-full text-left px-4 py-2 text-sm font-semibold text-blue-600 dark:text-blue-400 hover:bg-blue-50/60 dark:hover:bg-blue-950/30 transition-colors ${
+                hasCustomModels ? 'border-t border-gray-200 dark:border-gray-800' : ''
+              }`}
             >
-              + Add your own Key
+              + Add your own key
             </button>
           </div>
-          </>
-        )}
-      </div>
-    </>
+        </>
+      )}
+    </div>
   )
 }
 

--- a/Frontend/src/components/ui/ModelSelector.tsx
+++ b/Frontend/src/components/ui/ModelSelector.tsx
@@ -1,24 +1,16 @@
 import { useState, useEffect, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
 import { useModelStore } from '../../store/useModelStore'
-import { ChevronDown } from 'lucide-react'
-import { Input } from './input'
-import { Button } from './button'
-import { Label } from './label'
-import ProviderSelect from './ProviderSelect'
-import { getProviderById } from '../../lib/providers'
+import { Bot } from 'lucide-react'
 import { useKMS } from '../../hooks/useKMS'
 
 function ModelSelector() {
-  const { models, activeId, setActive, addModel: addModelToStore, removeModel, clearCustomModels } = useModelStore()
+  const navigate = useNavigate()
+  const { deleteAPIKey } = useKMS()
+  const { models, activeId, setActive, clearCustomModels } = useModelStore()
   const activeModel = models.find(m => m.id === activeId)
   const [open, setOpen] = useState(false)
-  const [showAdd, setShowAdd] = useState(false)
-  const [newModel, setNewModel] = useState({ provider: '', apiKey: '' })
   const dropdownRef = useRef<HTMLDivElement>(null)
-  const { storeAPIKey, deleteAPIKey, isLoading: isKmsLoading, error: kmsError } = useKMS()
-  const [localError, setLocalError] = useState<string | null>(null)
-  const [successMessage, setSuccessMessage] = useState<string | null>(null)
-  const [closeTimer, setCloseTimer] = useState<number | null>(null)
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -33,84 +25,27 @@ function ModelSelector() {
     }
   }, [open])
 
-  async function addModel(e: React.FormEvent<HTMLFormElement>) {
-    e.preventDefault()
-    setLocalError(null)
-    setSuccessMessage(null)
-
-    if (!newModel.provider.trim() || !newModel.apiKey.trim()) {
-      setLocalError('Provider and API key are required')
-      return
-    }
-
-    try {
-      // First store the API key via KMS so backend can use it via cookies
-      const result = await storeAPIKey(newModel.apiKey, newModel.provider)
-
-      if (!result.success) {
-        setLocalError(result.error || 'Failed to store API key')
-        return
-      }
-
-      const message = result.message || `API key for ${newModel.provider} stored successfully!`
-      setSuccessMessage(message)
-
-      // Generate a unique ID using the provider name and timestamp
-      const id = newModel.provider.toLowerCase().replace(/\s+/g, '-') + '-' + Date.now()
-
-      // Get the provider info to use the correct name
-      const providerInfo = getProviderById(newModel.provider)
-      const displayName = providerInfo?.displayName || newModel.provider
-
-      addModelToStore({ 
-        id, 
-        name: displayName, 
-        apiKey: newModel.apiKey,
-        provider: newModel.provider,
-        isCustom: true
-      })
-
-      setLocalError(null)
-      if (closeTimer) {
-        window.clearTimeout(closeTimer)
-      }
-      const timer = window.setTimeout(() => {
-        setShowAdd(false)
-        setSuccessMessage(null)
-        setNewModel({ provider: '', apiKey: '' })
-        setCloseTimer(null)
-      }, 1500)
-      setCloseTimer(timer)
-    } catch (err) {
-      setLocalError(err instanceof Error ? err.message : 'Failed to add model')
-    }
-  }
-
-  function closeAddModal() {
-    if (closeTimer) {
-      window.clearTimeout(closeTimer)
-      setCloseTimer(null)
-    }
-    setShowAdd(false)
-    setLocalError(null)
-    setSuccessMessage(null)
-    setNewModel({ provider: '', apiKey: '' })
-  }
-
   return (
     <>
       <div className="relative" ref={dropdownRef}>
         <button 
           onClick={() => setOpen(!open)} 
-          className="flex items-center gap-1.5 px-2.5 py-1 rounded-lg bg-white dark:bg-black border border-gray-200 dark:border-gray-800 text-xs hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors"
+          className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+          title="Select Model"
         >
-          <span className="font-medium">{activeModel?.name || 'Select Model'}</span>
-          <ChevronDown className={`w-3 h-3 transition-transform ${open ? 'rotate-180' : ''}`} />
+          <Bot className="w-4 h-4 text-gray-600 dark:text-gray-400" />
         </button>
         
         {open && (
-          <div className="absolute left-0 top-full mt-1.5 w-56 rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-black shadow-lg overflow-hidden z-50">
-            <div className="max-h-56 overflow-y-auto scrollbar-thin">
+          <>
+            <div className="fixed inset-0 z-40" onClick={() => setOpen(false)} />
+            <div className="absolute left-1/2 bottom-full mb-2 w-56 -translate-x-1/2 rounded-lg border border-gray-200 dark:border-gray-800 bg-white dark:bg-black shadow-xl overflow-hidden z-50">
+            <div className="absolute -top-1 left-1/2 -translate-x-1/2 w-2 h-2 bg-white dark:bg-black border-l border-t border-gray-200 dark:border-gray-800 rotate-45"></div>
+            <div className="px-3 py-2 border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900">
+              <div className="text-xs font-medium text-gray-600 dark:text-gray-400">Current Model</div>
+              <div className="text-sm font-semibold text-gray-900 dark:text-gray-100">{activeModel?.name || 'Select Model'}</div>
+            </div>
+            <div className="max-h-64 overflow-y-auto scrollbar-thin">
               {models.map(m => (
                 <button 
                   key={m.id}
@@ -137,7 +72,7 @@ function ModelSelector() {
                     setOpen(false) 
                   }} 
                   className={`w-full text-left px-3 py-1.5 text-xs hover:bg-gray-100 dark:hover:bg-gray-900 transition-colors ${
-                    m.id === activeId ? 'bg-gray-100 dark:bg-gray-900 font-medium' : ''
+                    m.id === activeId ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300' : ''
                   }`}
                 >
                   {m.name}
@@ -145,82 +80,18 @@ function ModelSelector() {
               ))}
             </div>
             <button 
-              onClick={() => { setShowAdd(true); setOpen(false) }} 
+              onClick={() => { 
+                setOpen(false)
+                navigate('/settings')
+              }} 
               className="w-full text-left px-3 py-1.5 text-xs border-t border-gray-200 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-900 transition-colors font-medium"
             >
               + Add your own Key
             </button>
           </div>
+          </>
         )}
       </div>
-
-      {showAdd && (
-        <div 
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
-          onClick={closeAddModal}
-        >
-          <div 
-            className="w-full max-w-md rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-black shadow-2xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="p-6">
-              <div className="flex items-center justify-between mb-6">
-                <h3 className="text-lg font-semibold">Add a Model</h3>
-                <button 
-                  onClick={closeAddModal} 
-                  className="p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-900 transition-colors"
-                >
-                  ✕
-                </button>
-              </div>
-              <form onSubmit={addModel} className="space-y-4">
-                <div className="space-y-2">
-                  <Label htmlFor="provider">Provider</Label>
-                  <ProviderSelect
-                    value={newModel.provider}
-                    onChange={value => setNewModel({...newModel, provider: value})}
-                    required
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="api-key">API Key</Label>
-                  <Input
-                    id="api-key"
-                    type="password"
-                    placeholder="Enter your key"
-                    value={newModel.apiKey}
-                    onChange={e => setNewModel({...newModel, apiKey: e.target.value})}
-                    required
-                  />
-                </div>
-                {(localError || kmsError) && (
-                  <div className="p-2 text-xs text-red-600 bg-red-50 dark:bg-red-900/20 rounded-md">
-                    {localError || kmsError}
-                  </div>
-                )}
-                {successMessage && (
-                  <div className="p-2 text-xs text-green-600 bg-green-50 dark:bg-green-900/20 rounded-md">
-                    {successMessage}
-                  </div>
-                )}
-                <div className="flex justify-end gap-3 pt-2">
-                  <Button 
-                    type="button" 
-                    variant="outline"
-                    onClick={() => setShowAdd(false)}
-                    disabled={isKmsLoading}
-                  >
-                    Cancel
-                  </Button>
-                  <Button type="submit" disabled={isKmsLoading}>
-                    {isKmsLoading ? 'Saving...' : 'Save Model'}
-                  </Button>
-                </div>
-              </form>
-            </div>
-          </div>
-        </div>
-      )}
     </>
   )
 }

--- a/Frontend/src/lib/models.ts
+++ b/Frontend/src/lib/models.ts
@@ -4,6 +4,7 @@ import { AVAILABLE_PROVIDERS, getProviderById } from '../lib/providers'
 // Form data for creating or updating a model
 export interface ModelFormData {
   provider: string
+  modelName: string
   apiKey: string
 }
 
@@ -12,13 +13,9 @@ export function createModelFromForm(formData: ModelFormData): Model {
   // Generate a unique ID using the provider name and timestamp
   const id = formData.provider.toLowerCase().replace(/\s+/g, '-') + '-' + Date.now()
   
-  // Get the provider info to use the correct name
-  const providerInfo = getProviderById(formData.provider)
-  const displayName = providerInfo?.displayName || formData.provider
-  
   return {
     id,
-    name: displayName,
+    name: formData.modelName || formData.provider,
     apiKey: formData.apiKey,
     provider: formData.provider,
     isCustom: true
@@ -27,12 +24,8 @@ export function createModelFromForm(formData: ModelFormData): Model {
 
 // Updates model data from form
 export function updateModelFromForm(formData: ModelFormData): Partial<Model> {
-  // Get the provider info to use the correct name
-  const providerInfo = getProviderById(formData.provider)
-  const displayName = providerInfo?.displayName || formData.provider
-  
   return {
-    name: displayName,
+    name: formData.modelName || formData.provider,
     apiKey: formData.apiKey,
     provider: formData.provider
   }
@@ -42,6 +35,7 @@ export function updateModelFromForm(formData: ModelFormData): Partial<Model> {
 export function modelToFormData(model: Model): ModelFormData {
   return {
     provider: model.provider || '',
+    modelName: model.name || '',
     apiKey: model.apiKey || ''
   }
 }
@@ -49,7 +43,7 @@ export function modelToFormData(model: Model): ModelFormData {
 // Validates model form data
 export function validateModelForm(formData: ModelFormData): boolean {
   const isValidProvider = AVAILABLE_PROVIDERS.some(provider => provider.id === formData.provider)
-  return formData.provider.trim() !== '' && formData.apiKey.trim() !== '' && isValidProvider
+  return formData.provider.trim() !== '' && formData.modelName.trim() !== '' && formData.apiKey.trim() !== '' && isValidProvider
 }
 
 // Gets available provider options

--- a/Frontend/src/lib/models.ts
+++ b/Frontend/src/lib/models.ts
@@ -1,5 +1,36 @@
 import { Model } from '../types'
-import { AVAILABLE_PROVIDERS, getProviderById } from '../lib/providers'
+import { AVAILABLE_PROVIDERS } from '../lib/providers'
+
+export interface ProviderModelOption {
+  value: string
+  label: string
+  provider: string
+  description?: string
+}
+
+const PROVIDER_MODEL_OPTIONS: Record<string, ProviderModelOption[]> = {
+  gemini: [
+    { value: 'gemini-3.1-pro', label: 'Gemini 3.1 Pro', provider: 'gemini', description: 'Highest quality, best for detailed reasoning' },
+    { value: 'gemini-3.1-flash', label: 'Gemini 3.1 Flash', provider: 'gemini', description: 'Faster, lower-latency option' },
+  ],
+  openai: [
+    { value: 'gpt-4.1-mini', label: 'GPT-4.1 Mini', provider: 'openai', description: 'Balanced quality and latency' },
+    { value: 'gpt-4o-mini', label: 'GPT-4o Mini', provider: 'openai', description: 'Great for lightweight tasks' },
+  ],
+}
+
+export function getModelOptionsForProvider(provider: string): ProviderModelOption[] {
+  return PROVIDER_MODEL_OPTIONS[provider] ?? []
+}
+
+export function getModelOption(provider: string, value: string): ProviderModelOption | undefined {
+  if (!provider || !value) return undefined
+  return getModelOptionsForProvider(provider).find(option => option.value === value)
+}
+
+export function getAllSupportedModelOptions(): ProviderModelOption[] {
+  return Object.values(PROVIDER_MODEL_OPTIONS).flat()
+}
 
 // Form data for creating or updating a model
 export interface ModelFormData {
@@ -12,10 +43,13 @@ export interface ModelFormData {
 export function createModelFromForm(formData: ModelFormData): Model {
   // Generate a unique ID using the provider name and timestamp
   const id = formData.provider.toLowerCase().replace(/\s+/g, '-') + '-' + Date.now()
+  const selectedModel = getModelOption(formData.provider, formData.modelName)
+  const displayName = selectedModel?.label || formData.modelName || formData.provider
   
   return {
     id,
-    name: formData.modelName || formData.provider,
+    name: displayName,
+    modelId: selectedModel?.value || formData.modelName,
     apiKey: formData.apiKey,
     provider: formData.provider,
     isCustom: true
@@ -24,8 +58,10 @@ export function createModelFromForm(formData: ModelFormData): Model {
 
 // Updates model data from form
 export function updateModelFromForm(formData: ModelFormData): Partial<Model> {
+  const selectedModel = getModelOption(formData.provider, formData.modelName)
   return {
-    name: formData.modelName || formData.provider,
+    name: selectedModel?.label || formData.modelName || formData.provider,
+    modelId: selectedModel?.value || formData.modelName,
     apiKey: formData.apiKey,
     provider: formData.provider
   }
@@ -35,7 +71,7 @@ export function updateModelFromForm(formData: ModelFormData): Partial<Model> {
 export function modelToFormData(model: Model): ModelFormData {
   return {
     provider: model.provider || '',
-    modelName: model.name || '',
+    modelName: model.modelId || '',
     apiKey: model.apiKey || ''
   }
 }
@@ -43,7 +79,14 @@ export function modelToFormData(model: Model): ModelFormData {
 // Validates model form data
 export function validateModelForm(formData: ModelFormData): boolean {
   const isValidProvider = AVAILABLE_PROVIDERS.some(provider => provider.id === formData.provider)
-  return formData.provider.trim() !== '' && formData.modelName.trim() !== '' && formData.apiKey.trim() !== '' && isValidProvider
+  const hasSupportedModel = !!getModelOption(formData.provider, formData.modelName)
+  return (
+    formData.provider.trim() !== '' &&
+    formData.modelName.trim() !== '' &&
+    formData.apiKey.trim() !== '' &&
+    isValidProvider &&
+    hasSupportedModel
+  )
 }
 
 // Gets available provider options

--- a/Frontend/src/pages/Settings.tsx
+++ b/Frontend/src/pages/Settings.tsx
@@ -1,28 +1,266 @@
-export const Settings = () => {
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { ArrowLeft, Globe, Palette, User, Plus } from 'lucide-react'
+import { useModelStore } from '../store/useModelStore'
+import { useUserStore } from '../store/useUserStore'
+import { useTheme } from '../hooks/useTheme'
+import { useKMS } from '../hooks/useKMS'
+import ModelList from '../components/ui/ModelList'
+import ModelForm from '../components/ui/ModelForm'
+import { Button } from '../components/ui/button'
+import {
+  createModelFromForm,
+  filterModels,
+  ModelFormData,
+  validateModelForm,
+} from '../lib/models'
+
+type SettingsTab = 'general' | 'models' | 'account'
+
+const Settings = () => {
+  const navigate = useNavigate()
+  const { models, addModel, removeModel } = useModelStore()
+  const { email, username, userId, accountCreatedAt, isAuthenticated } = useUserStore()
+  const { theme, setTheme } = useTheme()
+  const { deleteAPIKey } = useKMS()
+
+  const [activeTab, setActiveTab] = useState<SettingsTab>('models')
+  const [showAddModal, setShowAddModal] = useState(false)
+  const [formData, setFormData] = useState<ModelFormData>({ provider: '', modelName: '', apiKey: '' })
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null)
+
+  const { customModels, builtInModels } = filterModels(models)
+  const displayName = username || (email ? email.split('@')[0] : 'User')
+  const avatarInitial = displayName.charAt(0).toUpperCase()
+
+  const sidebarItems: { id: SettingsTab; label: string; icon: typeof User }[] = [
+    { id: 'general', label: 'General', icon: Palette },
+    { id: 'models', label: 'Models', icon: Globe },
+    { id: 'account', label: 'Account', icon: User },
+  ]
+
+  function handleAddModel(e: React.FormEvent) {
+    e.preventDefault()
+    if (!validateModelForm(formData)) return
+    addModel(createModelFromForm(formData))
+    closeModal()
+  }
+
+  function handleDeleteRequest(modelId: string) {
+    setConfirmDeleteId(modelId)
+  }
+
+  async function performDelete() {
+    if (!confirmDeleteId) return
+    const model = models.find((m) => m.id === confirmDeleteId)
+    if (!model) {
+      setConfirmDeleteId(null)
+      return
+    }
+
+    if (model.provider) {
+      try {
+        await deleteAPIKey(model.provider)
+      } catch (err) {
+        console.error('Failed to delete key via KMS', err)
+      }
+    }
+
+    removeModel(model.id)
+    setConfirmDeleteId(null)
+  }
+
+  function closeModal() {
+    setShowAddModal(false)
+    setFormData({ provider: '', modelName: '', apiKey: '' })
+  }
+
   return (
-    <div className="min-h-screen bg-gray-50 py-8 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-4xl mx-auto">
-        <div className="mb-8">
-          <h1 className="text-3xl font-bold text-gray-900">Settings</h1>
-          <p className="mt-2 text-sm text-gray-600">
-            Manage your API keys and preferences
-          </p>
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 text-gray-900 dark:text-white">
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <div className="flex items-center gap-4 mb-8">
+          <button
+            onClick={() => navigate('/chat')}
+            className="p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            title="Back to chat"
+          >
+            <ArrowLeft className="w-4 h-4" />
+          </button>
+          <div>
+            <h1 className="text-3xl font-bold">Settings</h1>
+            <p className="text-sm text-gray-600 dark:text-gray-400">
+              Manage models, API keys, and account preferences
+            </p>
+          </div>
         </div>
 
-        <div className="space-y-8">
-          <section>
-            <h2 className="text-xl font-semibold text-gray-800 mb-4">API Keys</h2>
-            <p className="text-sm text-gray-600 mb-2">
-              API keys are managed through the Settings modal accessed from the chat header (click your avatar → Settings). Open the <strong>Models</strong> tab to add or remove provider keys so the backend cookies stay in sync.
-            </p>
-            <p className="text-sm text-gray-500">
-              The same modal controls the model list used across the app, so any change there automatically updates the chat router integration.
-            </p>
-          </section>
+        <div className="bg-white dark:bg-gray-950 rounded-xl border border-gray-200 dark:border-gray-800 shadow-sm">
+          <div className="flex flex-col md:flex-row">
+            <aside className="w-full md:w-64 border-b md:border-b-0 md:border-r border-gray-200 dark:border-gray-800">
+              <nav className="p-4 space-y-2">
+                {sidebarItems.map((item) => (
+                  <button
+                    key={item.id}
+                    onClick={() => setActiveTab(item.id)}
+                    className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left transition-colors ${
+                      activeTab === item.id
+                        ? 'bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300'
+                        : 'hover:bg-gray-100 dark:hover:bg-gray-800 text-gray-600 dark:text-gray-300'
+                    }`}
+                  >
+                    <item.icon className="w-4 h-4" />
+                    <span className="font-medium text-sm">{item.label}</span>
+                  </button>
+                ))}
+              </nav>
+            </aside>
+
+            <section className="flex-1 p-6">
+              {activeTab === 'general' && (
+                <div className="space-y-6">
+                  <div>
+                    <h2 className="text-2xl font-semibold">General preferences</h2>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      Personalize the assistant experience
+                    </p>
+                  </div>
+
+                  <div className="space-y-4">
+                    <div className="border border-gray-200 dark:border-gray-800 rounded-lg p-4">
+                      <div className="flex items-center justify-between">
+                        <div>
+                          <h3 className="font-medium text-sm">Theme</h3>
+                          <p className="text-xs text-gray-600 dark:text-gray-400">
+                            Switch between light and dark UI themes
+                          </p>
+                        </div>
+                        <select
+                          value={theme}
+                          onChange={(e) => setTheme(e.target.value as 'light' | 'dark' | 'system')}
+                          className="px-3 py-2 rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 text-sm"
+                        >
+                          <option value="light">Light</option>
+                          <option value="dark">Dark</option>
+                          <option value="system">System</option>
+                        </select>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
+              {activeTab === 'models' && (
+                <div className="space-y-6">
+                  <div className="flex items-center justify-between">
+                    <div>
+                      <h2 className="text-2xl font-semibold">Models & API keys</h2>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">
+                        Add provider keys and organize custom model names
+                      </p>
+                    </div>
+                    <Button onClick={() => setShowAddModal(true)} className="flex items-center gap-2">
+                      <Plus className="w-4 h-4" />
+                      Add Model
+                    </Button>
+                  </div>
+
+                  <ModelList title="Available Models" models={builtInModels} isCustom={false} />
+
+                  <ModelList
+                    title="Your Models"
+                    models={customModels}
+                    onDelete={handleDeleteRequest}
+                    isCustom={true}
+                  />
+                </div>
+              )}
+
+              {activeTab === 'account' && (
+                <div className="space-y-6">
+                  <div>
+                    <h2 className="text-2xl font-semibold">Account</h2>
+                    <p className="text-sm text-gray-600 dark:text-gray-400">
+                      User profile and sign-in details
+                    </p>
+                  </div>
+
+                  <div className="border border-gray-200 dark:border-gray-800 rounded-lg p-6 flex items-center gap-4">
+                    <div className="w-16 h-16 rounded-full bg-gray-100 dark:bg-gray-800 flex items-center justify-center text-lg font-semibold">
+                      {avatarInitial}
+                    </div>
+                    <div>
+                      <p className="font-medium">{displayName}</p>
+                      <p className="text-sm text-gray-600 dark:text-gray-400">{email || 'Not signed in'}</p>
+                      {accountCreatedAt && (
+                        <p className="text-xs text-gray-500 dark:text-gray-500">
+                          Member since {new Date(accountCreatedAt).toLocaleDateString()}
+                        </p>
+                      )}
+                      {userId && (
+                        <p className="text-xs text-gray-500 dark:text-gray-500 mt-1">User ID: {userId}</p>
+                      )}
+                    </div>
+                  </div>
+                </div>
+              )}
+            </section>
+          </div>
         </div>
       </div>
-    </div>
-  );
-};
 
-export default Settings;
+      {showAddModal && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4" onClick={closeModal}>
+          <div
+            className="w-full max-w-md rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="p-6">
+              <div className="flex items-center justify-between mb-6">
+                <h3 className="text-lg font-semibold">Add a Key</h3>
+                <button
+                  onClick={closeModal}
+                  className="p-1 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+                >
+                  ✕
+                </button>
+              </div>
+              <ModelForm
+                formData={formData}
+                onFormChange={setFormData}
+                onSubmit={handleAddModel}
+                onCancel={closeModal}
+                isEditing={false}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      {confirmDeleteId && (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4" onClick={() => setConfirmDeleteId(null)}>
+          <div
+            className="w-full max-w-sm rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="p-6 space-y-4">
+              <h3 className="text-base font-semibold">Remove model</h3>
+              <p className="text-sm text-gray-600 dark:text-gray-400">
+                This also deletes the provider key stored in the backend vault.
+              </p>
+              <div className="flex justify-end gap-2">
+                <Button variant="outline" onClick={() => setConfirmDeleteId(null)}>
+                  Cancel
+                </Button>
+                <Button className="bg-red-600 hover:bg-red-700" onClick={performDelete}>
+                  Delete
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default Settings

--- a/Frontend/src/store/useChatStore.ts
+++ b/Frontend/src/store/useChatStore.ts
@@ -457,12 +457,14 @@ const chatStoreCreator: StateCreator<ChatState> = (set, get) => ({
     const isTempSession = selectedSessionId?.startsWith('temp-');
 
     try {
-      const { models, activeId } = useModelStore.getState();
-      const activeModel = models.find((m) => m.id === activeId);
+        const { models, activeId } = useModelStore.getState();
+        const activeModel = models.find((m) => m.id === activeId);
+        // The backend ChatRequest already expects `provider` + `model`, so updating this selection UI requires no server changes.
       const provider =
         activeModel?.provider === 'openai'
           ? 'openai'
           : 'gemini';
+      const modelValue = activeModel?.modelId || activeModel?.name || undefined;
 
       let fullResponse = '';
       let realSessionId = selectedSessionId || '';
@@ -475,6 +477,7 @@ const chatStoreCreator: StateCreator<ChatState> = (set, get) => ({
           query,
           session_id: !selectedSessionId || isTempSession ? undefined : selectedSessionId,
           provider,
+          model: modelValue,
           mode: 'generate',
         },
         (event) => {
@@ -561,6 +564,7 @@ const chatStoreCreator: StateCreator<ChatState> = (set, get) => ({
             activeModel?.provider === 'openai'
               ? 'openai'
               : 'gemini';
+          const modelValue = activeModel?.modelId || activeModel?.name || undefined;
 
           let fullResponse = '';
           let realSessionId = selectedSessionId || '';
@@ -573,6 +577,7 @@ const chatStoreCreator: StateCreator<ChatState> = (set, get) => ({
               query,
               session_id: !selectedSessionId || isTempSession ? undefined : selectedSessionId,
               provider,
+              model: modelValue,
               mode: 'generate',
             },
             (event) => {

--- a/Frontend/src/store/useModelStore.ts
+++ b/Frontend/src/store/useModelStore.ts
@@ -14,15 +14,39 @@ interface ModelState {
   clearCustomModels: () => void
 }
 
-// Default models available in the application
+// Default models available in the application (mirrors backend-supported presets)
 const DEFAULT_MODELS: StoredModel[] = [
-  { 
-    id: 'default',
-    name: 'default',
-    provider: 'default',
-    requiresApiKey: false
-  }
+  {
+    id: 'gemini-3.1-pro',
+    name: 'Gemini 3.1 Pro',
+    modelId: 'gemini-3.1-pro',
+    provider: 'gemini',
+    requiresApiKey: false,
+  },
+  {
+    id: 'gemini-3.1-flash',
+    name: 'Gemini 3.1 Flash',
+    modelId: 'gemini-3.1-flash',
+    provider: 'gemini',
+    requiresApiKey: false,
+  },
+  {
+    id: 'gpt-4.1-mini',
+    name: 'GPT-4.1 Mini',
+    modelId: 'gpt-4.1-mini',
+    provider: 'openai',
+    requiresApiKey: true,
+  },
+  {
+    id: 'gpt-4o-mini',
+    name: 'GPT-4o Mini',
+    modelId: 'gpt-4o-mini',
+    provider: 'openai',
+    requiresApiKey: true,
+  },
 ];
+
+const STORAGE_VERSION = 1
 
 // Manages the collection of available models and the currently active model
 export const useModelStore = create<ModelState>()(
@@ -53,27 +77,49 @@ export const useModelStore = create<ModelState>()(
       
       // Remove a model by ID
       removeModel: (id) =>
-        set((state) => ({
-          models: state.models.filter((m) => m.id !== id),
-          // If removing the active model, fall back to the first available model
-          activeId: state.activeId === id ? state.models[0]?.id || '' : state.activeId,
-        })),
+        set((state) => {
+          const remaining = state.models.filter((m) => m.id !== id)
+          return {
+            models: remaining,
+            activeId: state.activeId === id ? remaining[0]?.id || '' : state.activeId,
+          }
+        }),
 
       // Remove all custom models
       clearCustomModels: () =>
         set((state) => {
           const builtInModels = state.models.filter((m) => !m.isCustom)
           const isCustomActive = state.models.find(m => m.id === state.activeId)?.isCustom
-          
+
           return {
             models: builtInModels,
-            // If active model was custom, switch to default
-            activeId: isCustomActive ? builtInModels[0]?.id || '' : state.activeId
+            // If active model was custom, switch to first built-in option
+            activeId: isCustomActive ? builtInModels[0]?.id || '' : state.activeId,
           }
         }),
     }),
     {
       name: 'model-storage',
+      version: STORAGE_VERSION,
+      migrate: (persistedState, version) => {
+        if (!persistedState) return persistedState
+
+        const storedModels = Array.isArray(persistedState.models) ? persistedState.models : []
+        const customModels = storedModels.filter((model) => model.isCustom)
+
+        const mergedModels = [
+          ...DEFAULT_MODELS,
+          ...customModels,
+        ]
+
+        const activeIdExists = mergedModels.some((model) => model.id === persistedState.activeId)
+
+        return {
+          ...persistedState,
+          models: mergedModels,
+          activeId: activeIdExists ? persistedState.activeId : DEFAULT_MODELS[0].id,
+        }
+      },
     }
   )
 )

--- a/Frontend/src/types/index.ts
+++ b/Frontend/src/types/index.ts
@@ -6,6 +6,7 @@ export * from './chat';
 export interface Model {
   id: string;
   name: string;
+  modelId?: string;
   provider?: string;
   apiKey?: string;
   isCustom?: boolean;


### PR DESCRIPTION
# Pull Request

## Description

- add a dedicated Settings dashboard so users can add/list/remove provider API keys
- wire the chat model selector to route people to Settings and reuse the shared KMS utilities.
## Type of Change

-  New feature
## Checklist

- I have reviewed and tested my changes, and I have run the code to confirm it works properly
## How Has This Been Tested?

- npm run dev (frontend) to verify the Settings page and model selector flows
- python -m app.run (backend) to confirm the KMS endpoints and CORS changes

